### PR TITLE
General improvements to generated documentation

### DIFF
--- a/elem/elem.gen.go
+++ b/elem/elem.gen.go
@@ -2,12 +2,18 @@
 
 // Package elem defines markup to create DOM elements.
 //
-// Generated from "HTML element reference" by Mozilla Contributors, https://developer.mozilla.org/en-US/docs/Web/HTML/Element, licensed under CC-BY-SA 2.5.
+// Generated from "HTML element reference" by Mozilla Contributors,
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element, licensed under
+// CC-BY-SA 2.5.
 package elem
 
 import "github.com/gopherjs/vecty"
 
-// The HTML Anchor Element (<a>) defines a hyperlink to a location on the same page or any other page on the Web. It can also be used (in an obsolete way) to create an anchor point—a destination for hyperlinks within the content of a page, so that links aren't limited to connecting simply to the top of a page.
+// The HTML Anchor Element (<a>) defines a hyperlink to a location on the same
+// page or any other page on the Web. It can also be used (in an obsolete way)
+// to create an anchor point—a destination for hyperlinks within the content
+// of a page, so that links aren't limited to connecting simply to the top of a
+// page.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 func Anchor(markup ...vecty.Markup) *vecty.Element {
@@ -16,7 +22,9 @@ func Anchor(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <abbr> element (or HTML Abbreviation Element) represents an abbreviation and optionally provides a full description for it. If present, the title attribute must contain this full description and nothing else.
+// Abbreviation (or HTML Abbreviation Element) represents an abbreviation and
+// optionally provides a full description for it. If present, the title
+// attribute must contain this full description and nothing else.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
 func Abbreviation(markup ...vecty.Markup) *vecty.Element {
@@ -25,7 +33,8 @@ func Abbreviation(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <address> element supplies contact information for its nearest <article> or <body> ancestor; in the latter case, it applies to the whole document.
+// Address supplies contact information for its nearest <article> or <body>
+// ancestor; in the latter case, it applies to the whole document.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
 func Address(markup ...vecty.Markup) *vecty.Element {
@@ -34,7 +43,8 @@ func Address(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <area> element defines a hot-spot region on an image, and optionally associates it with a hypertext link. This element is used only within a <map> element.
+// Area defines a hot-spot region on an image, and optionally associates it
+// with a hypertext link. This element is used only within a <map> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/area
 func Area(markup ...vecty.Markup) *vecty.Element {
@@ -43,7 +53,12 @@ func Area(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <article> element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication). This could be a forum post, a magazine or newspaper article, a blog entry, an object, or any other independent item of content. Each <article> should be identified, typically by including a heading (<h1>-<h6> element) as a child of the <article> element.
+// Article represents a self-contained composition in a document, page,
+// application, or site, which is intended to be independently distributable or
+// reusable (e.g., in syndication). This could be a forum post, a magazine or
+// newspaper article, a blog entry, an object, or any other independent item of
+// content. Each <article> should be identified, typically by including a
+// heading (<h1>-<h6> element) as a child of the <article> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
 func Article(markup ...vecty.Markup) *vecty.Element {
@@ -52,7 +67,13 @@ func Article(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <aside> element represents a section of the page with content connected tangentially to the rest, which could be considered separate from that content. These sections are often represented as sidebars or inserts. They often contain the definitions on the sidebars, such as definitions from the glossary; there may also be other types of information, such as related advertisements; the biography of the author; web applications; profile information or related links on the blog.
+// Aside represents a section of the page with content connected tangentially
+// to the rest, which could be considered separate from that content. These
+// sections are often represented as sidebars or inserts. They often contain
+// the definitions on the sidebars, such as definitions from the glossary;
+// there may also be other types of information, such as related
+// advertisements; the biography of the author; web applications; profile
+// information or related links on the blog.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
 func Aside(markup ...vecty.Markup) *vecty.Element {
@@ -61,7 +82,9 @@ func Aside(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <audio> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element; the browser will choose the most suitable one.
+// Audio is used to embed sound content in documents. It may contain one or
+// more audio sources, represented using the src attribute or the <source>
+// element; the browser will choose the most suitable one.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
 func Audio(markup ...vecty.Markup) *vecty.Element {
@@ -70,7 +93,11 @@ func Audio(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <b> Element represents a span of text stylistically different from normal text, without conveying any special importance or relevance. It is typically used for keywords in a summary, product names in a review, or other spans of text whose typical presentation would be boldfaced. Another example of its use is to mark the lead sentence of each paragraph of an article.
+// Bold represents a span of text stylistically different from normal text,
+// without conveying any special importance or relevance. It is typically used
+// for keywords in a summary, product names in a review, or other spans of text
+// whose typical presentation would be boldfaced. Another example of its use is
+// to mark the lead sentence of each paragraph of an article.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
 func Bold(markup ...vecty.Markup) *vecty.Element {
@@ -79,7 +106,8 @@ func Bold(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <base> element specifies the base URL to use for all relative URLs contained within a document. There can be only one <base> element in a document.
+// Base specifies the base URL to use for all relative URLs contained within a
+// document. There can be only one <base> element in a document.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
 func Base(markup ...vecty.Markup) *vecty.Element {
@@ -88,7 +116,9 @@ func Base(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <bdi> Element (or Bi-Directional Isolation Element) isolates a span of text that might be formatted in a different direction from other text outside it.
+// BidirectionalIsolation (or Bi-Directional Isolation Element) isolates a span
+// of text that might be formatted in a different direction from other text
+// outside it.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
 func BidirectionalIsolation(markup ...vecty.Markup) *vecty.Element {
@@ -97,7 +127,9 @@ func BidirectionalIsolation(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <bdo> Element (or HTML bidirectional override element) is used to override the current directionality of text. It causes the directionality of the characters to be ignored in favor of the specified directionality.
+// BidirectionalOverride (or HTML bidirectional override element) is used to
+// override the current directionality of text. It causes the directionality of
+// the characters to be ignored in favor of the specified directionality.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
 func BidirectionalOverride(markup ...vecty.Markup) *vecty.Element {
@@ -106,7 +138,11 @@ func BidirectionalOverride(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <blockquote> Element (or HTML Block Quotation Element) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the <cite> element.
+// BlockQuote (or HTML Block Quotation Element) indicates that the enclosed
+// text is an extended quotation. Usually, this is rendered visually by
+// indentation (see Notes for how to change it). A URL for the source of the
+// quotation may be given using the cite attribute, while a text representation
+// of the source can be given using the <cite> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
 func BlockQuote(markup ...vecty.Markup) *vecty.Element {
@@ -115,7 +151,9 @@ func BlockQuote(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML element line break <br> produces a line break in text (carriage-return). It is useful for writing a poem or an address, where the division of lines is significant.
+// The HTML element line break <br> produces a line break in text
+// (carriage-return). It is useful for writing a poem or an address, where the
+// division of lines is significant.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
 func Break(markup ...vecty.Markup) *vecty.Element {
@@ -124,7 +162,7 @@ func Break(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <button> Element represents a clickable button.
+// Button represents a clickable button.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
 func Button(markup ...vecty.Markup) *vecty.Element {
@@ -133,7 +171,11 @@ func Button(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <canvas> Element can be used to draw graphics via scripting (usually JavaScript). For example, it can be used to draw graphs, make photo compositions or even perform animations. You may (and should) provide alternate content inside the <canvas> block. That content will be rendered both on older browsers that don't support canvas and in browsers with JavaScript disabled.
+// Canvas can be used to draw graphics via scripting (usually JavaScript). For
+// example, it can be used to draw graphs, make photo compositions or even
+// perform animations. You may (and should) provide alternate content inside
+// the <canvas> block. That content will be rendered both on older browsers
+// that don't support canvas and in browsers with JavaScript disabled.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
 func Canvas(markup ...vecty.Markup) *vecty.Element {
@@ -142,7 +184,9 @@ func Canvas(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <caption> Element (or HTML Table Caption Element) represents the title of a table. Though it is always the first descendant of a <table>, its styling, using CSS, may place it elsewhere, relative to the table.
+// Caption (or HTML Table Caption Element) represents the title of a table.
+// Though it is always the first descendant of a <table>, its styling, using
+// CSS, may place it elsewhere, relative to the table.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
 func Caption(markup ...vecty.Markup) *vecty.Element {
@@ -151,7 +195,10 @@ func Caption(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Citation Element (<cite>) represents a reference to a creative work. It must include the title of a work or a URL reference, which may be in an abbreviated form according to the conventions used for the addition of citation metadata.
+// The HTML Citation Element (<cite>) represents a reference to a creative
+// work. It must include the title of a work or a URL reference, which may be
+// in an abbreviated form according to the conventions used for the addition of
+// citation metadata.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
 func Citation(markup ...vecty.Markup) *vecty.Element {
@@ -160,7 +207,8 @@ func Citation(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Code Element (<code>) represents a fragment of computer code. By default, it is displayed in the browser's default monospace font.
+// The HTML Code Element (<code>) represents a fragment of computer code. By
+// default, it is displayed in the browser's default monospace font.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
 func Code(markup ...vecty.Markup) *vecty.Element {
@@ -169,7 +217,9 @@ func Code(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Table Column Element (<col>) defines a column within a table and is used for defining common semantics on all common cells. It is generally found within a <colgroup> element.
+// The HTML Table Column Element (<col>) defines a column within a table and is
+// used for defining common semantics on all common cells. It is generally
+// found within a <colgroup> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
 func Column(markup ...vecty.Markup) *vecty.Element {
@@ -178,7 +228,8 @@ func Column(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Table Column Group Element (<colgroup>) defines a group of columns within a table.
+// The HTML Table Column Group Element (<colgroup>) defines a group of columns
+// within a table.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
 func ColumnGroup(markup ...vecty.Markup) *vecty.Element {
@@ -187,7 +238,8 @@ func ColumnGroup(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <data> Element links a given content with a machine-readable translation. If the content is time- or date-related, the <time> must be used.
+// Data links a given content with a machine-readable translation. If the
+// content is time- or date-related, the <time> must be used.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data
 func Data(markup ...vecty.Markup) *vecty.Element {
@@ -196,7 +248,8 @@ func Data(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Datalist Element (<datalist>) contains a set of <option> elements that represent the values available for other controls.
+// The HTML Datalist Element (<datalist>) contains a set of <option> elements
+// that represent the values available for other controls.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
 func DataList(markup ...vecty.Markup) *vecty.Element {
@@ -205,7 +258,9 @@ func DataList(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <dd> element (HTML Description Element) indicates the description of a term in a description list (<dl>) element. This element can occur only as a child element of a description list and it must follow a <dt> element.
+// Description (HTML Description Element) indicates the description of a term
+// in a description list (<dl>) element. This element can occur only as a child
+// element of a description list and it must follow a <dt> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 func Description(markup ...vecty.Markup) *vecty.Element {
@@ -214,7 +269,9 @@ func Description(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Deleted Text Element (<del>) represents a range of text that has been deleted from a document. This element is often (but need not be) rendered with strike-through text.
+// The HTML Deleted Text Element (<del>) represents a range of text that has
+// been deleted from a document. This element is often (but need not be)
+// rendered with strike-through text.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
 func DeletedText(markup ...vecty.Markup) *vecty.Element {
@@ -223,7 +280,8 @@ func DeletedText(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Details Element (<details>) is used as a disclosure widget from which the user can retrieve additional information.
+// The HTML Details Element (<details>) is used as a disclosure widget from
+// which the user can retrieve additional information.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
 func Details(markup ...vecty.Markup) *vecty.Element {
@@ -232,7 +290,8 @@ func Details(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Definition Element (<dfn>) represents the defining instance of a term.
+// The HTML Definition Element (<dfn>) represents the defining instance of a
+// term.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
 func Definition(markup ...vecty.Markup) *vecty.Element {
@@ -241,7 +300,11 @@ func Definition(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <dialog> element represents a dialog box or other interactive component, such as an inspector or window. <form> elements can be integrated within a dialog by specifying them with the attribute method="dialog". When such a form is submitted, the dialog is closed with a returnValue attribute set to the value of the submit button used.
+// Dialog represents a dialog box or other interactive component, such as an
+// inspector or window. <form> elements can be integrated within a dialog by
+// specifying them with the attribute method="dialog". When such a form is
+// submitted, the dialog is closed with a returnValue attribute set to the
+// value of the submit button used.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog
 func Dialog(markup ...vecty.Markup) *vecty.Element {
@@ -250,7 +313,11 @@ func Dialog(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <div> element (or HTML Document Division Element) is the generic container for flow content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang. It should be used only when no other semantic element (such as <article> or <nav>) is appropriate.
+// Div (or HTML Document Division Element) is the generic container for flow
+// content, which does not inherently represent anything. It can be used to
+// group elements for styling purposes (using the class or id attributes), or
+// because they share attribute values, such as lang. It should be used only
+// when no other semantic element (such as <article> or <nav>) is appropriate.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
 func Div(markup ...vecty.Markup) *vecty.Element {
@@ -259,7 +326,9 @@ func Div(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <dl> element (or HTML Description List Element) encloses a list of pairs of terms and descriptions. Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs).
+// DescriptionList (or HTML Description List Element) encloses a list of pairs
+// of terms and descriptions. Common uses for this element are to implement a
+// glossary or to display metadata (a list of key-value pairs).
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
 func DescriptionList(markup ...vecty.Markup) *vecty.Element {
@@ -268,7 +337,11 @@ func DescriptionList(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <dt> element (or HTML Definition Term Element) identifies a term in a definition list. This element can occur only as a child element of a <dl>. It is usually followed by a <dd> element; however, multiple <dt> elements in a row indicate several terms that are all defined by the immediate next <dd> element.
+// DefinitionTerm (or HTML Definition Term Element) identifies a term in a
+// definition list. This element can occur only as a child element of a <dl>.
+// It is usually followed by a <dd> element; however, multiple <dt> elements in
+// a row indicate several terms that are all defined by the immediate next <dd>
+// element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
 func DefinitionTerm(markup ...vecty.Markup) *vecty.Element {
@@ -277,7 +350,7 @@ func DefinitionTerm(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <element> element is used to define new custom DOM elements.
+// Element is used to define new custom DOM elements.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/element
 func Element(markup ...vecty.Markup) *vecty.Element {
@@ -286,7 +359,9 @@ func Element(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML element emphasis  <em> marks text that has stress emphasis. The <em> element can be nested, with each level of nesting indicating a greater degree of emphasis.
+// The HTML element emphasis  <em> marks text that has stress emphasis. The
+// <em> element can be nested, with each level of nesting indicating a greater
+// degree of emphasis.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
 func Emphasis(markup ...vecty.Markup) *vecty.Element {
@@ -295,7 +370,8 @@ func Emphasis(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <embed> Element represents an integration point for an external application or interactive content (in other words, a plug-in).
+// Embed represents an integration point for an external application or
+// interactive content (in other words, a plug-in).
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
 func Embed(markup ...vecty.Markup) *vecty.Element {
@@ -304,7 +380,8 @@ func Embed(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <fieldset> element is used to group several controls as well as labels (<label>) within a web form.
+// FieldSet is used to group several controls as well as labels (<label>)
+// within a web form.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
 func FieldSet(markup ...vecty.Markup) *vecty.Element {
@@ -313,7 +390,12 @@ func FieldSet(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <figcaption> element represents a caption or a legend associated with a figure or an illustration described by the rest of the data of the <figure> element which is its immediate ancestor which means <figcaption> can be the first or last element inside a <figure> block. Also, the HTML Figcaption Element is optional; if not provided, then the parent figure element will have no caption.
+// FigureCaption represents a caption or a legend associated with a figure or
+// an illustration described by the rest of the data of the <figure> element
+// which is its immediate ancestor which means <figcaption> can be the first or
+// last element inside a <figure> block. Also, the HTML Figcaption Element is
+// optional; if not provided, then the parent figure element will have no
+// caption.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
 func FigureCaption(markup ...vecty.Markup) *vecty.Element {
@@ -322,7 +404,12 @@ func FigureCaption(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <figure> element represents self-contained content, frequently with a caption (<figcaption>), and is typically referenced as a single unit. While it is related to the main flow, its position is independent of the main flow. Usually this is an image, an illustration, a diagram, a code snippet, or a schema that is referenced in the main text, but that can be moved to another page or to an appendix without affecting the main flow.
+// Figure represents self-contained content, frequently with a caption
+// (<figcaption>), and is typically referenced as a single unit. While it is
+// related to the main flow, its position is independent of the main flow.
+// Usually this is an image, an illustration, a diagram, a code snippet, or a
+// schema that is referenced in the main text, but that can be moved to another
+// page or to an appendix without affecting the main flow.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
 func Figure(markup ...vecty.Markup) *vecty.Element {
@@ -331,7 +418,9 @@ func Figure(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <footer> element represents a footer for its nearest sectioning content or sectioning root element. A footer typically contains information about the author of the section, copyright data or links to related documents.
+// Footer represents a footer for its nearest sectioning content or sectioning
+// root element. A footer typically contains information about the author of
+// the section, copyright data or links to related documents.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
 func Footer(markup ...vecty.Markup) *vecty.Element {
@@ -340,7 +429,8 @@ func Footer(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <form> element represents a document section that contains interactive controls to submit information to a web server.
+// Form represents a document section that contains interactive controls to
+// submit information to a web server.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
 func Form(markup ...vecty.Markup) *vecty.Element {
@@ -349,7 +439,9 @@ func Form(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <header> element represents a group of introductory or navigational aids. It may contain some heading elements but also other elements like a logo, wrapped section's header, a search form, and so on.
+// Header represents a group of introductory or navigational aids. It may
+// contain some heading elements but also other elements like a logo, wrapped
+// section's header, a search form, and so on.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
 func Header(markup ...vecty.Markup) *vecty.Element {
@@ -358,7 +450,10 @@ func Header(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <hgroup> Element (HTML Headings Group Element) represents the heading of a section. It defines a single title that participates in the outline of the document as the heading of the implicit or explicit section that it belongs to.
+// HeadingsGroup (HTML Headings Group Element) represents the heading of a
+// section. It defines a single title that participates in the outline of the
+// document as the heading of the implicit or explicit section that it belongs
+// to.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup
 func HeadingsGroup(markup ...vecty.Markup) *vecty.Element {
@@ -367,7 +462,11 @@ func HeadingsGroup(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <hr> element represents a thematic break between paragraph-level elements (for example, a change of scene in a story, or a shift of topic with a section). In previous versions of HTML, it represented a horizontal rule. It may still be displayed as a horizontal rule in visual browsers, but is now defined in semantic terms, rather than presentational terms.
+// HorizontalRule represents a thematic break between paragraph-level elements
+// (for example, a change of scene in a story, or a shift of topic with a
+// section). In previous versions of HTML, it represented a horizontal rule. It
+// may still be displayed as a horizontal rule in visual browsers, but is now
+// defined in semantic terms, rather than presentational terms.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
 func HorizontalRule(markup ...vecty.Markup) *vecty.Element {
@@ -376,7 +475,9 @@ func HorizontalRule(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <i> Element represents a range of text that is set off from the normal text for some reason, for example, technical terms, foreign language phrases, or fictional character thoughts. It is typically displayed in italic type.
+// Italic represents a range of text that is set off from the normal text for
+// some reason, for example, technical terms, foreign language phrases, or
+// fictional character thoughts. It is typically displayed in italic type.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
 func Italic(markup ...vecty.Markup) *vecty.Element {
@@ -385,7 +486,14 @@ func Italic(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Inline Frame Element (<iframe>) represents a nested browsing context, effectively embedding another HTML page into the current page. In HTML 4.01, a document may contain a head and a body or a head and a frameset, but not both a body and a frameset. However, an <iframe> can be used within a normal document body. Each browsing context has its own session history and active document. The browsing context that contains the embedded content is called the parent browsing context. The top-level browsing context (which has no parent) is typically the browser window.
+// The HTML Inline Frame Element (<iframe>) represents a nested browsing
+// context, effectively embedding another HTML page into the current page. In
+// HTML 4.01, a document may contain a head and a body or a head and a
+// frameset, but not both a body and a frameset. However, an <iframe> can be
+// used within a normal document body. Each browsing context has its own
+// session history and active document. The browsing context that contains the
+// embedded content is called the parent browsing context. The top-level
+// browsing context (which has no parent) is typically the browser window.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
 func InlineFrame(markup ...vecty.Markup) *vecty.Element {
@@ -394,7 +502,7 @@ func InlineFrame(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <img> element represents an image in the document.
+// Image represents an image in the document.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
 func Image(markup ...vecty.Markup) *vecty.Element {
@@ -403,7 +511,9 @@ func Image(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML element <input> is used to create interactive controls for web-based forms in order to accept data from the user. How an <input> works varies considerably depending on the value of its type attribute.
+// The HTML element <input> is used to create interactive controls for
+// web-based forms in order to accept data from the user. How an <input> works
+// varies considerably depending on the value of its type attribute.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 func Input(markup ...vecty.Markup) *vecty.Element {
@@ -412,7 +522,8 @@ func Input(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <ins> Element (or HTML Inserted Text) HTML represents a range of text that has been added to a document.
+// InsertedText (or HTML Inserted Text) HTML represents a range of text that
+// has been added to a document.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
 func InsertedText(markup ...vecty.Markup) *vecty.Element {
@@ -421,7 +532,8 @@ func InsertedText(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Keyboard Input Element (<kbd>) represents user input and produces an inline element displayed in the browser's default monospace font.
+// The HTML Keyboard Input Element (<kbd>) represents user input and produces
+// an inline element displayed in the browser's default monospace font.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
 func KeyboardInput(markup ...vecty.Markup) *vecty.Element {
@@ -430,7 +542,11 @@ func KeyboardInput(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Label Element (<label>) represents a caption for an item in a user interface. It can be associated with a control either by placing the control element inside the <label> element, or by using the for attribute. Such a control is called the labeled control of the label element. One input can be associated with multiple labels.
+// The HTML Label Element (<label>) represents a caption for an item in a user
+// interface. It can be associated with a control either by placing the control
+// element inside the <label> element, or by using the for attribute. Such a
+// control is called the labeled control of the label element. One input can be
+// associated with multiple labels.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
 func Label(markup ...vecty.Markup) *vecty.Element {
@@ -439,7 +555,8 @@ func Label(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <legend> Element (or HTML Legend Field Element) represents a caption for the content of its parent <fieldset>.
+// Legend (or HTML Legend Field Element) represents a caption for the content
+// of its parent <fieldset>.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
 func Legend(markup ...vecty.Markup) *vecty.Element {
@@ -448,7 +565,12 @@ func Legend(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <li> element (or HTML List Item Element) is used to represent an item in a list. It must be contained in a parent element: an ordered list (<ol>), an unordered list (<ul>), or a menu (<menu>). In menus and unordered lists, list items are usually displayed using bullet points. In ordered lists, they are usually displayed with an ascending counter on the left, such as a number or letter.
+// ListItem (or HTML List Item Element) is used to represent an item in a list.
+// It must be contained in a parent element: an ordered list (<ol>), an
+// unordered list (<ul>), or a menu (<menu>). In menus and unordered lists,
+// list items are usually displayed using bullet points. In ordered lists, they
+// are usually displayed with an ascending counter on the left, such as a
+// number or letter.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
 func ListItem(markup ...vecty.Markup) *vecty.Element {
@@ -457,7 +579,9 @@ func ListItem(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <link> element specifies relationships between the current document and an external resource. Possible uses for this element include defining a relational framework for navigation. This Element is most used to link to style sheets.
+// Link specifies relationships between the current document and an external
+// resource. Possible uses for this element include defining a relational
+// framework for navigation. This Element is most used to link to style sheets.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
 func Link(markup ...vecty.Markup) *vecty.Element {
@@ -466,7 +590,13 @@ func Link(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <main> element represents the main content of  the <body> of a document or application. The main content area consists of content that is directly related to, or expands upon the central topic of a document or the central functionality of an application. This content should be unique to the document, excluding any content that is repeated across a set of documents such as sidebars, navigation links, copyright information, site logos, and search forms (unless the document's main function is as a search form).
+// Main represents the main content of  the <body> of a document or
+// application. The main content area consists of content that is directly
+// related to, or expands upon the central topic of a document or the central
+// functionality of an application. This content should be unique to the
+// document, excluding any content that is repeated across a set of documents
+// such as sidebars, navigation links, copyright information, site logos, and
+// search forms (unless the document's main function is as a search form).
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
 func Main(markup ...vecty.Markup) *vecty.Element {
@@ -475,7 +605,8 @@ func Main(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <map> element is used with <area> elements to define an image map (a clickable link area).
+// Map is used with <area> elements to define an image map (a clickable link
+// area).
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map
 func Map(markup ...vecty.Markup) *vecty.Element {
@@ -484,7 +615,10 @@ func Map(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Mark Element (<mark>) represents highlighted text, i.e., a run of text marked for reference purpose, due to its relevance in a particular context. For example it can be used in a page showing search results to highlight every instance of the searched-for word.
+// The HTML Mark Element (<mark>) represents highlighted text, i.e., a run of
+// text marked for reference purpose, due to its relevance in a particular
+// context. For example it can be used in a page showing search results to
+// highlight every instance of the searched-for word.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
 func Mark(markup ...vecty.Markup) *vecty.Element {
@@ -493,7 +627,10 @@ func Mark(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <menu> element represents a group of commands that a user can perform or activate. This includes both list menus, which might appear across the top of a screen, as well as context menus, such as those that might appear underneath a button after it has been clicked.
+// Menu represents a group of commands that a user can perform or activate.
+// This includes both list menus, which might appear across the top of a
+// screen, as well as context menus, such as those that might appear underneath
+// a button after it has been clicked.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
 func Menu(markup ...vecty.Markup) *vecty.Element {
@@ -502,7 +639,9 @@ func Menu(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <menuitem> element represents a command that a user is able to invoke through a popup menu. This includes context menus, as well as menus that might be attached to a menu button.
+// MenuItem represents a command that a user is able to invoke through a popup
+// menu. This includes context menus, as well as menus that might be attached
+// to a menu button.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menuitem
 func MenuItem(markup ...vecty.Markup) *vecty.Element {
@@ -511,7 +650,9 @@ func MenuItem(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <meta> element represents any metadata information that cannot be represented by one of the other HTML meta-related elements (<base>, <link>, <script>, <style> or <title>).
+// Meta represents any metadata information that cannot be represented by one
+// of the other HTML meta-related elements (<base>, <link>, <script>, <style>
+// or <title>).
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta
 func Meta(markup ...vecty.Markup) *vecty.Element {
@@ -520,7 +661,8 @@ func Meta(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <meter> Element represents either a scalar value within a known range or a fractional value.
+// Meter represents either a scalar value within a known range or a fractional
+// value.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
 func Meter(markup ...vecty.Markup) *vecty.Element {
@@ -529,7 +671,9 @@ func Meter(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <nav> element (HTML Navigation Element) represents a section of a page that links to other pages or to parts within the page: a section with navigation links.
+// Navigation (HTML Navigation Element) represents a section of a page that
+// links to other pages or to parts within the page: a section with navigation
+// links.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
 func Navigation(markup ...vecty.Markup) *vecty.Element {
@@ -538,7 +682,8 @@ func Navigation(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// <noframes> is an HTML element which is used to supporting browsers which are not able to support <frame> elements or configured to do so.
+// <noframes> is an HTML element which is used to supporting browsers which are
+// not able to support <frame> elements or configured to do so.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noframes
 func NoFrames(markup ...vecty.Markup) *vecty.Element {
@@ -547,7 +692,8 @@ func NoFrames(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <noscript> Element defines a section of html to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser.
+// NoScript defines a section of html to be inserted if a script type on the
+// page is unsupported or if scripting is currently turned off in the browser.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript
 func NoScript(markup ...vecty.Markup) *vecty.Element {
@@ -556,7 +702,9 @@ func NoScript(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Embedded Object Element (<object>) represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin.
+// The HTML Embedded Object Element (<object>) represents an external resource,
+// which can be treated as an image, a nested browsing context, or a resource
+// to be handled by a plugin.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
 func Object(markup ...vecty.Markup) *vecty.Element {
@@ -565,7 +713,12 @@ func Object(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <ol> Element (or HTML Ordered List Element) represents an ordered list of items. Typically, ordered-list items are displayed with a preceding numbering, which can be of any form, like numerals, letters or Romans numerals or even simple bullets. This numbered style is not defined in the HTML description of the page, but in its associated CSS, using the list-style-type property.
+// OrderedList (or HTML Ordered List Element) represents an ordered list of
+// items. Typically, ordered-list items are displayed with a preceding
+// numbering, which can be of any form, like numerals, letters or Romans
+// numerals or even simple bullets. This numbered style is not defined in the
+// HTML description of the page, but in its associated CSS, using the
+// list-style-type property.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
 func OrderedList(markup ...vecty.Markup) *vecty.Element {
@@ -574,7 +727,8 @@ func OrderedList(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// In a Web form, the HTML <optgroup> element  creates a grouping of options within a <select> element.
+// In a Web form, the HTML <optgroup> element  creates a grouping of options
+// within a <select> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
 func OptionsGroup(markup ...vecty.Markup) *vecty.Element {
@@ -583,7 +737,9 @@ func OptionsGroup(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// In a Web form, the HTML <option> element is used to create a control representing an item within a <select>, an <optgroup> or a <datalist> HTML5 element.
+// In a Web form, the HTML <option> element is used to create a control
+// representing an item within a <select>, an <optgroup> or a <datalist> HTML5
+// element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
 func Option(markup ...vecty.Markup) *vecty.Element {
@@ -592,7 +748,7 @@ func Option(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <output> element represents the result of a calculation or user action.
+// Output represents the result of a calculation or user action.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
 func Output(markup ...vecty.Markup) *vecty.Element {
@@ -601,7 +757,7 @@ func Output(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <p> element (or HTML Paragraph Element) represents a paragraph of text.
+// Paragraph (or HTML Paragraph Element) represents a paragraph of text.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
 func Paragraph(markup ...vecty.Markup) *vecty.Element {
@@ -610,7 +766,7 @@ func Paragraph(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <param> Element (or HTML Parameter Element) defines parameters for <object>.
+// Parameter (or HTML Parameter Element) defines parameters for <object>.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param
 func Parameter(markup ...vecty.Markup) *vecty.Element {
@@ -619,7 +775,11 @@ func Parameter(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <picture> element is a container used to specify multiple <source> elements for a specific <img> contained in it. The browser will choose the most suitable source according to the current layout of the page (the constraints of the box the image will appear in) and the device it will be displayed on (e.g. a normal or hiDPI device.)
+// Picture is a container used to specify multiple <source> elements for a
+// specific <img> contained in it. The browser will choose the most suitable
+// source according to the current layout of the page (the constraints of the
+// box the image will appear in) and the device it will be displayed on (e.g. a
+// normal or hiDPI device.)
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture
 func Picture(markup ...vecty.Markup) *vecty.Element {
@@ -628,7 +788,10 @@ func Picture(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <pre> element (or HTML Preformatted Text) represents preformatted text. Text within this element is typically displayed in a non-proportional ("monospace") font exactly as it is laid out in the file. Whitespace inside this element is displayed as typed.
+// Preformatted (or HTML Preformatted Text) represents preformatted text. Text
+// within this element is typically displayed in a non-proportional
+// ("monospace") font exactly as it is laid out in the file. Whitespace inside
+// this element is displayed as typed.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
 func Preformatted(markup ...vecty.Markup) *vecty.Element {
@@ -637,7 +800,10 @@ func Preformatted(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <progress> Element is used to view the completion progress of a task. While the specifics of how it's displayed is left up to the browser developer, it's typically displayed as a progress bar. Javascript can be used to manipulate the value of progress bar.
+// Progress is used to view the completion progress of a task. While the
+// specifics of how it's displayed is left up to the browser developer, it's
+// typically displayed as a progress bar. Javascript can be used to manipulate
+// the value of progress bar.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
 func Progress(markup ...vecty.Markup) *vecty.Element {
@@ -646,7 +812,9 @@ func Progress(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Quote Element (<q>) indicates that the enclosed text is a short inline quotation. This element is intended for short quotations that don't require paragraph breaks; for long quotations use <blockquote> element.
+// The HTML Quote Element (<q>) indicates that the enclosed text is a short
+// inline quotation. This element is intended for short quotations that don't
+// require paragraph breaks; for long quotations use <blockquote> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
 func Quote(markup ...vecty.Markup) *vecty.Element {
@@ -655,7 +823,12 @@ func Quote(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <rp> element is used to provide fall-back parenthesis for browsers non-supporting ruby annotations. Ruby annotations are for showing pronunciation of East Asian characters, like using Japanese furigana or Taiwainese bopomofo characters. The <rp> element is used in the case of lack of <ruby> element support its content has what should be displayed in order to indicate the presence of a ruby annotation, usually parentheses.
+// RubyParenthesis is used to provide fall-back parenthesis for browsers
+// non-supporting ruby annotations. Ruby annotations are for showing
+// pronunciation of East Asian characters, like using Japanese furigana or
+// Taiwainese bopomofo characters. The <rp> element is used in the case of lack
+// of <ruby> element support its content has what should be displayed in order
+// to indicate the presence of a ruby annotation, usually parentheses.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
 func RubyParenthesis(markup ...vecty.Markup) *vecty.Element {
@@ -664,7 +837,9 @@ func RubyParenthesis(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <rt> Element embraces pronunciation of characters presented in a ruby annotations, which are used to describe the pronunciation of East Asian characters. This element is always used inside a <ruby> element.
+// RubyText embraces pronunciation of characters presented in a ruby
+// annotations, which are used to describe the pronunciation of East Asian
+// characters. This element is always used inside a <ruby> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
 func RubyText(markup ...vecty.Markup) *vecty.Element {
@@ -673,7 +848,9 @@ func RubyText(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <rtc> Element embraces semantic annotations of characters presented in a ruby of <rb> elements used inside of <ruby> element. <rb> elements can have both pronunciation (<rt>) and semantic (<rtc>) annotations.
+// RubyTextContainer embraces semantic annotations of characters presented in a
+// ruby of <rb> elements used inside of <ruby> element. <rb> elements can have
+// both pronunciation (<rt>) and semantic (<rtc>) annotations.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rtc
 func RubyTextContainer(markup ...vecty.Markup) *vecty.Element {
@@ -682,7 +859,8 @@ func RubyTextContainer(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <ruby> Element represents a ruby annotation. Ruby annotations are for showing pronunciation of East Asian characters.
+// Ruby represents a ruby annotation. Ruby annotations are for showing
+// pronunciation of East Asian characters.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
 func Ruby(markup ...vecty.Markup) *vecty.Element {
@@ -691,7 +869,11 @@ func Ruby(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Strikethrough Element (<s>) renders text with a strikethrough, or a line through it. Use the <s> element to represent things that are no longer relevant or no longer accurate. However, <s> is not appropriate when indicating document edits; for that, use the <del> and <ins> elements, as appropriate.
+// The HTML Strikethrough Element (<s>) renders text with a strikethrough, or a
+// line through it. Use the <s> element to represent things that are no longer
+// relevant or no longer accurate. However, <s> is not appropriate when
+// indicating document edits; for that, use the <del> and <ins> elements, as
+// appropriate.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
 func Strikethrough(markup ...vecty.Markup) *vecty.Element {
@@ -700,7 +882,9 @@ func Strikethrough(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <samp> element is an element intended to identify sample output from a computer program. It is usually displayed in the browser's default monotype font (such as Lucida Console).
+// Sample is an element intended to identify sample output from a computer
+// program. It is usually displayed in the browser's default monotype font
+// (such as Lucida Console).
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
 func Sample(markup ...vecty.Markup) *vecty.Element {
@@ -709,7 +893,8 @@ func Sample(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Script Element (<script>) is used to embed or reference an executable script within an HTML or XHTML document.
+// The HTML Script Element (<script>) is used to embed or reference an
+// executable script within an HTML or XHTML document.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
 func Script(markup ...vecty.Markup) *vecty.Element {
@@ -718,7 +903,10 @@ func Script(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <section> element represents a generic section of a document, i.e., a thematic grouping of content, typically with a heading. Each <section> should be identified, typically by including a heading (<h1>-<h6> element) as a child of the <section> element.
+// Section represents a generic section of a document, i.e., a thematic
+// grouping of content, typically with a heading. Each <section> should be
+// identified, typically by including a heading (<h1>-<h6> element) as a child
+// of the <section> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
 func Section(markup ...vecty.Markup) *vecty.Element {
@@ -727,7 +915,10 @@ func Section(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML select (<select>) element represents a control that presents a menu of options. The options within the menu are represented by <option> elements, which can be grouped by <optgroup> elements. Options can be pre-selected for the user.
+// The HTML select (<select>) element represents a control that presents a menu
+// of options. The options within the menu are represented by <option>
+// elements, which can be grouped by <optgroup> elements. Options can be
+// pre-selected for the user.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
 func Select(markup ...vecty.Markup) *vecty.Element {
@@ -736,7 +927,9 @@ func Select(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <shadow> element is used as a shadow DOM insertion point. You might use it if you have created multiple shadow roots under a shadow host. It is not useful in ordinary HTML. It is used with Web Components.
+// Shadow is used as a shadow DOM insertion point. You might use it if you have
+// created multiple shadow roots under a shadow host. It is not useful in
+// ordinary HTML. It is used with Web Components.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Shadow
 func Shadow(markup ...vecty.Markup) *vecty.Element {
@@ -745,7 +938,11 @@ func Shadow(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Small Element (<small>) makes the text font size one size smaller (for example, from large to medium, or from small to x-small) down to the browser's minimum font size.  In HTML5, this element is repurposed to represent side-comments and small print, including copyright and legal text, independent of its styled presentation.
+// The HTML Small Element (<small>) makes the text font size one size smaller
+// (for example, from large to medium, or from small to x-small) down to the
+// browser's minimum font size.  In HTML5, this element is repurposed to
+// represent side-comments and small print, including copyright and legal text,
+// independent of its styled presentation.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
 func Small(markup ...vecty.Markup) *vecty.Element {
@@ -754,7 +951,10 @@ func Small(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <source> element specifies multiple media resources for either the <picture>, the <audio> or the <video> element. It is an empty element. It is commonly used to serve the same media content in multiple formats supported by different browsers.
+// Source specifies multiple media resources for either the <picture>, the
+// <audio> or the <video> element. It is an empty element. It is commonly used
+// to serve the same media content in multiple formats supported by different
+// browsers.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
 func Source(markup ...vecty.Markup) *vecty.Element {
@@ -763,7 +963,10 @@ func Source(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <span> element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang.
+// Span is a generic inline container for phrasing content, which does not
+// inherently represent anything. It can be used to group elements for styling
+// purposes (using the class or id attributes), or because they share attribute
+// values, such as lang.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
 func Span(markup ...vecty.Markup) *vecty.Element {
@@ -772,7 +975,8 @@ func Span(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Strong Element (<strong>) gives text strong importance, and is typically displayed in bold.
+// The HTML Strong Element (<strong>) gives text strong importance, and is
+// typically displayed in bold.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
 func Strong(markup ...vecty.Markup) *vecty.Element {
@@ -781,7 +985,9 @@ func Strong(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <style> element contains style information for a document, or part of a document. By default, the style instructions written inside that element are expected to be CSS.
+// Style contains style information for a document, or part of a document. By
+// default, the style instructions written inside that element are expected to
+// be CSS.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
 func Style(markup ...vecty.Markup) *vecty.Element {
@@ -790,7 +996,9 @@ func Style(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Subscript Element (<sub>) defines a span of text that should be displayed, for typographic reasons, lower, and often smaller, than the main span of text.
+// The HTML Subscript Element (<sub>) defines a span of text that should be
+// displayed, for typographic reasons, lower, and often smaller, than the main
+// span of text.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub
 func Subscript(markup ...vecty.Markup) *vecty.Element {
@@ -799,7 +1007,8 @@ func Subscript(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML summary element (<summary>) is used as a summary, caption, or legend for the content of a <details> element.
+// The HTML summary element (<summary>) is used as a summary, caption, or
+// legend for the content of a <details> element.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
 func Summary(markup ...vecty.Markup) *vecty.Element {
@@ -808,7 +1017,9 @@ func Summary(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Superscript Element (<sup>) defines a span of text that should be displayed, for typographic reasons, higher, and often smaller, than the main span of text.
+// The HTML Superscript Element (<sup>) defines a span of text that should be
+// displayed, for typographic reasons, higher, and often smaller, than the main
+// span of text.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup
 func Superscript(markup ...vecty.Markup) *vecty.Element {
@@ -817,7 +1028,8 @@ func Superscript(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Table Element (<table>) represents tabular data: information expressed via two dimensions or more.
+// The HTML Table Element (<table>) represents tabular data: information
+// expressed via two dimensions or more.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
 func Table(markup ...vecty.Markup) *vecty.Element {
@@ -826,7 +1038,20 @@ func Table(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Table Body Element (<tbody>) defines one or more <tr> element data-rows to be the body of its parent <table> element (as long as no <tr> elements are immediate children of that table element.)  In conjunction with a preceding <thead> and/or <tfoot> element, <tbody> provides additional semantic information for devices such as printers and displays. Of the parent table's child elements, <tbody> represents the content which, when longer than a page, will most likely differ for each page printed; while the content of <thead> and <tfoot> will be the same or similar for each page printed. For displays, <tbody> will enable separate scrolling of the <thead>, <tfoot>, and <caption> elements of the same parent <table> element.  Note that unlike the <thead>, <tfoot>, and <caption> elements however, multiple <tbody> elements are permitted (if consecutive), allowing the data-rows in long tables to be divided into different sections, each separately formatted as needed.
+// The HTML Table Body Element (<tbody>) defines one or more <tr> element
+// data-rows to be the body of its parent <table> element (as long as no <tr>
+// elements are immediate children of that table element.)  In conjunction with
+// a preceding <thead> and/or <tfoot> element, <tbody> provides additional
+// semantic information for devices such as printers and displays. Of the
+// parent table's child elements, <tbody> represents the content which, when
+// longer than a page, will most likely differ for each page printed; while the
+// content of <thead> and <tfoot> will be the same or similar for each page
+// printed. For displays, <tbody> will enable separate scrolling of the
+// <thead>, <tfoot>, and <caption> elements of the same parent <table> element.
+//  Note that unlike the <thead>, <tfoot>, and <caption> elements however,
+// multiple <tbody> elements are permitted (if consecutive), allowing the
+// data-rows in long tables to be divided into different sections, each
+// separately formatted as needed.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
 func TableBody(markup ...vecty.Markup) *vecty.Element {
@@ -835,7 +1060,8 @@ func TableBody(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The Table cell HTML element (<td>) defines a cell of a table that contains data. It participates in the table model.
+// The Table cell HTML element (<td>) defines a cell of a table that contains
+// data. It participates in the table model.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
 func TableData(markup ...vecty.Markup) *vecty.Element {
@@ -844,7 +1070,9 @@ func TableData(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML template element <template> is a mechanism for holding client-side content that is not to be rendered when a page is loaded but may subsequently be instantiated during runtime using JavaScript. 
+// The HTML template element <template> is a mechanism for holding client-side
+// content that is not to be rendered when a page is loaded but may
+// subsequently be instantiated during runtime using JavaScript. 
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template
 func Template(markup ...vecty.Markup) *vecty.Element {
@@ -853,7 +1081,7 @@ func Template(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <textarea> element represents a multi-line plain-text editing control.
+// TextArea represents a multi-line plain-text editing control.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
 func TextArea(markup ...vecty.Markup) *vecty.Element {
@@ -862,7 +1090,8 @@ func TextArea(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Table Foot Element (<tfoot>) defines a set of rows summarizing the columns of the table.
+// The HTML Table Foot Element (<tfoot>) defines a set of rows summarizing the
+// columns of the table.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
 func TableFoot(markup ...vecty.Markup) *vecty.Element {
@@ -871,7 +1100,9 @@ func TableFoot(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML element table header cell <th> defines a cell as a header for a group of cells of a table. The group of cells that the header refers to is defined by the scope and headers attribute.
+// The HTML element table header cell <th> defines a cell as a header for a
+// group of cells of a table. The group of cells that the header refers to is
+// defined by the scope and headers attribute.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
 func TableHeader(markup ...vecty.Markup) *vecty.Element {
@@ -880,7 +1111,8 @@ func TableHeader(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Table Head Element (<thead>) defines a set of rows defining the head of the columns of the table.
+// The HTML Table Head Element (<thead>) defines a set of rows defining the
+// head of the columns of the table.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
 func TableHead(markup ...vecty.Markup) *vecty.Element {
@@ -889,7 +1121,8 @@ func TableHead(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <time> element represents either a time on a 24-hour clock or a precise date in the Gregorian calendar (with optional time and timezone information).
+// Time represents either a time on a 24-hour clock or a precise date in the
+// Gregorian calendar (with optional time and timezone information).
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
 func Time(markup ...vecty.Markup) *vecty.Element {
@@ -898,7 +1131,9 @@ func Time(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <title> element defines the title of the document, shown in a browser's title bar or on the page's tab. It can only contain text, and any contained tags are ignored.
+// Title defines the title of the document, shown in a browser's title bar or
+// on the page's tab. It can only contain text, and any contained tags are
+// ignored.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
 func Title(markup ...vecty.Markup) *vecty.Element {
@@ -907,7 +1142,8 @@ func Title(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML element table row <tr> defines a row of cells in a table. Those can be a mix of <td> and <th> elements.
+// The HTML element table row <tr> defines a row of cells in a table. Those can
+// be a mix of <td> and <th> elements.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
 func TableRow(markup ...vecty.Markup) *vecty.Element {
@@ -916,7 +1152,10 @@ func TableRow(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <track> element is used as a child of the media elements—<audio> and <video>. It lets you specify timed text tracks (or time-based data), for example to automatically handle subtitles. The tracks are formatted in WebVTT format (.vtt files) — Web Video Text Tracks.
+// Track is used as a child of the media elements—<audio> and <video>. It
+// lets you specify timed text tracks (or time-based data), for example to
+// automatically handle subtitles. The tracks are formatted in WebVTT format
+// (.vtt files) — Web Video Text Tracks.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
 func Track(markup ...vecty.Markup) *vecty.Element {
@@ -925,7 +1164,8 @@ func Track(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Underline Element (<u>) renders text with an underline, a line under the baseline of its content.
+// The HTML Underline Element (<u>) renders text with an underline, a line
+// under the baseline of its content.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
 func Underline(markup ...vecty.Markup) *vecty.Element {
@@ -934,7 +1174,13 @@ func Underline(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML <ul> element (or HTML Unordered List Element) represents an unordered list of items, namely a collection of items that do not have a numerical ordering, and their order in the list is meaningless. Typically, unordered-list items are displayed with a bullet, which can be of several forms, like a dot, a circle or a squared. The bullet style is not defined in the HTML description of the page, but in its associated CSS, using the list-style-type property.
+// UnorderedList (or HTML Unordered List Element) represents an unordered list
+// of items, namely a collection of items that do not have a numerical
+// ordering, and their order in the list is meaningless. Typically,
+// unordered-list items are displayed with a bullet, which can be of several
+// forms, like a dot, a circle or a squared. The bullet style is not defined in
+// the HTML description of the page, but in its associated CSS, using the
+// list-style-type property.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
 func UnorderedList(markup ...vecty.Markup) *vecty.Element {
@@ -943,7 +1189,8 @@ func UnorderedList(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML Variable Element (<var>) represents a variable in a mathematical expression or a programming context.
+// The HTML Variable Element (<var>) represents a variable in a mathematical
+// expression or a programming context.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
 func Variable(markup ...vecty.Markup) *vecty.Element {
@@ -952,7 +1199,10 @@ func Variable(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// Use the  HTML <video> element to embed video content in a document. The video element contains one or more video sources. To specify a video source, use either the src attribute or the <source> element; the browser will choose the most suitable one.
+// Use the  HTML <video> element to embed video content in a document. The
+// video element contains one or more video sources. To specify a video source,
+// use either the src attribute or the <source> element; the browser will
+// choose the most suitable one.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
 func Video(markup ...vecty.Markup) *vecty.Element {
@@ -961,7 +1211,9 @@ func Video(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// The HTML element word break opportunity <wbr> represents a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location.
+// The HTML element word break opportunity <wbr> represents a position within
+// text where the browser may optionally break a line, though its line-breaking
+// rules would not otherwise create a break at that location.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
 func WordBreakOpportunity(markup ...vecty.Markup) *vecty.Element {
@@ -970,7 +1222,11 @@ func WordBreakOpportunity(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// Heading elements implement six levels of document headings, <h1> is the most important and <h6> is the least. A heading element briefly describes the topic of the section it introduces. Heading information may be used by user agents, for example, to construct a table of contents for a document automatically.
+// Heading elements implement six levels of document headings, <h1> is the most
+// important and <h6> is the least. A heading element briefly describes the
+// topic of the section it introduces. Heading information may be used by user
+// agents, for example, to construct a table of contents for a document
+// automatically.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
 func Header1(markup ...vecty.Markup) *vecty.Element {
@@ -979,7 +1235,11 @@ func Header1(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// Heading elements implement six levels of document headings, <h1> is the most important and <h6> is the least. A heading element briefly describes the topic of the section it introduces. Heading information may be used by user agents, for example, to construct a table of contents for a document automatically.
+// Heading elements implement six levels of document headings, <h1> is the most
+// important and <h6> is the least. A heading element briefly describes the
+// topic of the section it introduces. Heading information may be used by user
+// agents, for example, to construct a table of contents for a document
+// automatically.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
 func Header2(markup ...vecty.Markup) *vecty.Element {
@@ -988,7 +1248,11 @@ func Header2(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// Heading elements implement six levels of document headings, <h1> is the most important and <h6> is the least. A heading element briefly describes the topic of the section it introduces. Heading information may be used by user agents, for example, to construct a table of contents for a document automatically.
+// Heading elements implement six levels of document headings, <h1> is the most
+// important and <h6> is the least. A heading element briefly describes the
+// topic of the section it introduces. Heading information may be used by user
+// agents, for example, to construct a table of contents for a document
+// automatically.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
 func Header3(markup ...vecty.Markup) *vecty.Element {
@@ -997,7 +1261,11 @@ func Header3(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// Heading elements implement six levels of document headings, <h1> is the most important and <h6> is the least. A heading element briefly describes the topic of the section it introduces. Heading information may be used by user agents, for example, to construct a table of contents for a document automatically.
+// Heading elements implement six levels of document headings, <h1> is the most
+// important and <h6> is the least. A heading element briefly describes the
+// topic of the section it introduces. Heading information may be used by user
+// agents, for example, to construct a table of contents for a document
+// automatically.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
 func Header4(markup ...vecty.Markup) *vecty.Element {
@@ -1006,7 +1274,11 @@ func Header4(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// Heading elements implement six levels of document headings, <h1> is the most important and <h6> is the least. A heading element briefly describes the topic of the section it introduces. Heading information may be used by user agents, for example, to construct a table of contents for a document automatically.
+// Heading elements implement six levels of document headings, <h1> is the most
+// important and <h6> is the least. A heading element briefly describes the
+// topic of the section it introduces. Heading information may be used by user
+// agents, for example, to construct a table of contents for a document
+// automatically.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
 func Header5(markup ...vecty.Markup) *vecty.Element {
@@ -1015,7 +1287,11 @@ func Header5(markup ...vecty.Markup) *vecty.Element {
 	return e
 }
 
-// Heading elements implement six levels of document headings, <h1> is the most important and <h6> is the least. A heading element briefly describes the topic of the section it introduces. Heading information may be used by user agents, for example, to construct a table of contents for a document automatically.
+// Heading elements implement six levels of document headings, <h1> is the most
+// important and <h6> is the least. A heading element briefly describes the
+// topic of the section it introduces. Heading information may be used by user
+// agents, for example, to construct a table of contents for a document
+// automatically.
 //
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements
 func Header6(markup ...vecty.Markup) *vecty.Element {

--- a/elem/generate.go
+++ b/elem/generate.go
@@ -11,6 +11,12 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
+// elemNameMap translates lowercase HTML tag names from the MDN source into a
+// proper Go style name with MixedCaps and initialisms:
+//
+//  https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps
+//  https://github.com/golang/go/wiki/CodeReviewComments#initialisms
+//
 var elemNameMap = map[string]string{
 	"a":          "Anchor",
 	"abbr":       "Abbreviation",

--- a/elem/generate.go
+++ b/elem/generate.go
@@ -91,7 +91,9 @@ func main() {
 
 // Package elem defines markup to create DOM elements.
 //
-// Generated from "HTML element reference" by Mozilla Contributors, https://developer.mozilla.org/en-US/docs/Web/HTML/Element, licensed under CC-BY-SA 2.5.
+// Generated from "HTML element reference" by Mozilla Contributors,
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element, licensed under
+// CC-BY-SA 2.5.
 package elem
 
 import "github.com/gopherjs/vecty"
@@ -135,8 +137,7 @@ func writeElem(w io.Writer, name, desc, link string) {
 		funName = capitalize(name)
 	}
 
-	fmt.Fprintf(w, `
-// %s
+	fmt.Fprintf(w, `%s
 //
 // https://developer.mozilla.org%s
 func %s(markup ...vecty.Markup) *vecty.Element {
@@ -144,9 +145,23 @@ func %s(markup ...vecty.Markup) *vecty.Element {
 	vecty.List(markup).Apply(e)
 	return e
 }
-`, desc, link, funName, name)
+`, descToComments(desc), link, funName, name)
 }
 
 func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func descToComments(desc string) string {
+	c := ""
+	length := 80
+	for _, word := range strings.Split(desc, " ") {
+		if length+len(word)+1 > 80 {
+			length = 3
+			c += "\n//"
+		}
+		c += " " + word
+		length += len(word) + 1
+	}
+	return c
 }

--- a/elem/generate.go
+++ b/elem/generate.go
@@ -137,6 +137,25 @@ func writeElem(w io.Writer, name, desc, link string) {
 		funName = capitalize(name)
 	}
 
+	// Descriptions for elements generally read as:
+	//
+	//  The HTML <foobar> element ...
+	//
+	// Because these are consistent (sometimes with varying captalization,
+	// however) we can exploit that fact to reword the documentation in proper
+	// Go style:
+	//
+	//  Foobar ...
+	//
+	generalLowercase := fmt.Sprintf("the html <%s> element", strings.ToLower(name))
+
+	// Replace a number of 'no-break space' unicode characters which exist in
+	// the descriptions with normal spaces.
+	desc = strings.Replace(desc, "\u00a0", " ", -1)
+	if l := len(generalLowercase); len(desc) > l && strings.HasPrefix(strings.ToLower(desc), generalLowercase) {
+		desc = fmt.Sprintf("%s%s", funName, desc[l:])
+	}
+
 	fmt.Fprintf(w, `%s
 //
 // https://developer.mozilla.org%s

--- a/event/event.gen.go
+++ b/event/event.gen.go
@@ -2,1006 +2,1111 @@
 
 // Package event defines markup to bind DOM events.
 //
-// Generated from "Event reference" by Mozilla Contributors, https://developer.mozilla.org/en-US/docs/Web/Events, licensed under CC-BY-SA 2.5.
+// Generated from "Event reference" by Mozilla Contributors,
+// https://developer.mozilla.org/en-US/docs/Web/Events, licensed under
+// CC-BY-SA 2.5.
 package event
 
 import "github.com/gopherjs/vecty"
 
-// A transaction has been aborted.
+// Abort is an event fired when a transaction has been aborted.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/abort_indexedDB
 func Abort(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "abort", Listener: listener}
 }
 
-// The associated document has started printing or the print preview has been closed.
+// AfterPrint is an event fired when the associated document has started
+// printing or the print preview has been closed.
 //
 // https://developer.mozilla.org/docs/Web/Events/afterprint
 func AfterPrint(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "afterprint", Listener: listener}
 }
 
-// A CSS animation has completed.
+// AnimationEnd is an event fired when a CSS animation has completed.
 //
 // https://developer.mozilla.org/docs/Web/Events/animationend
 func AnimationEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "animationend", Listener: listener}
 }
 
-// A CSS animation is repeated.
+// AnimationIteration is an event fired when a CSS animation is repeated.
 //
 // https://developer.mozilla.org/docs/Web/Events/animationiteration
 func AnimationIteration(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "animationiteration", Listener: listener}
 }
 
-// A CSS animation has started.
+// AnimationStart is an event fired when a CSS animation has started.
 //
 // https://developer.mozilla.org/docs/Web/Events/animationstart
 func AnimationStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "animationstart", Listener: listener}
 }
 
-// The user agent has finished capturing audio for speech recognition.
+// AudioEnd is an event fired when the user agent has finished capturing audio
+// for speech recognition.
 //
 // https://developer.mozilla.org/docs/Web/Events/audioend
 func AudioEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "audioend", Listener: listener}
 }
 
-// The input buffer of a ScriptProcessorNode is ready to be processed.
+// AudioProcess is an event fired when the input buffer of a
+// ScriptProcessorNode is ready to be processed.
 //
 // https://developer.mozilla.org/docs/Web/Events/audioprocess
 func AudioProcess(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "audioprocess", Listener: listener}
 }
 
-// The user agent has started to capture audio for speech recognition.
+// AudioStart is an event fired when the user agent has started to capture
+// audio for speech recognition.
 //
 // https://developer.mozilla.org/docs/Web/Events/audiostart
 func AudioStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "audiostart", Listener: listener}
 }
 
-// The associated document is about to be printed or previewed for printing.
+// BeforePrint is an event fired when the associated document is about to be
+// printed or previewed for printing.
 //
 // https://developer.mozilla.org/docs/Web/Events/beforeprint
 func BeforePrint(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "beforeprint", Listener: listener}
 }
 
-// The window, the document and its resources are about to be unloaded.
+// BeforeUnload is an event fired when the window, the document and its
+// resources are about to be unloaded.
 //
 // https://developer.mozilla.org/docs/Web/Events/beforeunload
 func BeforeUnload(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "beforeunload", Listener: listener}
 }
 
-// A SMIL animation element begins.
+// BeginEvent is an event fired when a SMIL animation element begins.
 //
 // https://developer.mozilla.org/docs/Web/Events/beginEvent
 func BeginEvent(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "beginEvent", Listener: listener}
 }
 
-// An open connection to a database is blocking a versionchange transaction on the same database.
+// Blocked is an event fired when an open connection to a database is blocking
+// a versionchange transaction on the same database.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/blocked_indexedDB
 func Blocked(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "blocked", Listener: listener}
 }
 
-// An element has lost focus (does not bubble).
+// Blur is an event fired when an element has lost focus (does not bubble).
 //
 // https://developer.mozilla.org/docs/Web/Events/blur
 func Blur(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "blur", Listener: listener}
 }
 
-// The spoken utterance reaches a word or sentence boundary
+// Boundary is an event fired when the spoken utterance reaches a word or
+// sentence boundary
 //
 // https://developer.mozilla.org/docs/Web/Events/boundary
 func Boundary(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "boundary", Listener: listener}
 }
 
-// The resources listed in the manifest have been downloaded, and the application is now cached.
+// Cached is an event fired when the resources listed in the manifest have been
+// downloaded, and the application is now cached.
 //
 // https://developer.mozilla.org/docs/Web/Events/cached
 func Cached(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "cached", Listener: listener}
 }
 
-// The user agent can play the media, but estimates that not enough data has been loaded to play the media up to its end without having to stop for further buffering of content.
+// CanPlay is an event fired when the user agent can play the media, but
+// estimates that not enough data has been loaded to play the media up to its
+// end without having to stop for further buffering of content.
 //
 // https://developer.mozilla.org/docs/Web/Events/canplay
 func CanPlay(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "canplay", Listener: listener}
 }
 
-// The user agent can play the media, and estimates that enough data has been loaded to play the media up to its end without having to stop for further buffering of content.
+// CanPlayThrough is an event fired when the user agent can play the media, and
+// estimates that enough data has been loaded to play the media up to its end
+// without having to stop for further buffering of content.
 //
 // https://developer.mozilla.org/docs/Web/Events/canplaythrough
 func CanPlayThrough(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "canplaythrough", Listener: listener}
 }
 
-// The change event is fired for <input>, <select>, and <textarea> elements when a change to the element's value is committed by the user.
+// Change is an event fired when the change event is fired for <input>,
+// <select>, and <textarea> elements when a change to the element's value is
+// committed by the user.
 //
 // https://developer.mozilla.org/docs/Web/Events/change
 func Change(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "change", Listener: listener}
 }
 
-// The battery begins or stops charging.
+// ChargingChange is an event fired when the battery begins or stops charging.
 //
 // https://developer.mozilla.org/docs/Web/Events/chargingchange
 func ChargingChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "chargingchange", Listener: listener}
 }
 
-// The chargingTime attribute has been updated.
+// ChargingTimeChange is an event fired when the chargingTime attribute has
+// been updated.
 //
 // https://developer.mozilla.org/docs/Web/Events/chargingtimechange
 func ChargingTimeChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "chargingtimechange", Listener: listener}
 }
 
-// The user agent is checking for an update, or attempting to download the cache manifest for the first time.
+// Checking is an event fired when the user agent is checking for an update, or
+// attempting to download the cache manifest for the first time.
 //
 // https://developer.mozilla.org/docs/Web/Events/checking
 func Checking(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "checking", Listener: listener}
 }
 
-// A pointing device button has been pressed and released on an element.
+// Click is an event fired when a pointing device button has been pressed and
+// released on an element.
 //
 // https://developer.mozilla.org/docs/Web/Events/click
 func Click(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "click", Listener: listener}
 }
 
-// A WebSocket connection has been closed.
+// Close is an event fired when a WebSocket connection has been closed.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/close_websocket
 func Close(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "close", Listener: listener}
 }
 
-// The rendering of an OfflineAudioContext is terminated.
+// Complete is an event fired when the rendering of an OfflineAudioContext is
+// terminated.
 //
 // https://developer.mozilla.org/docs/Web/Events/complete
 func Complete(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "complete", Listener: listener}
 }
 
-// The composition of a passage of text has been completed or canceled.
+// CompositionEnd is an event fired when the composition of a passage of text
+// has been completed or canceled.
 //
 // https://developer.mozilla.org/docs/Web/Events/compositionend
 func CompositionEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "compositionend", Listener: listener}
 }
 
-// The composition of a passage of text is prepared (similar to keydown for a keyboard input, but works with other inputs such as speech recognition).
+// CompositionStart is an event fired when the composition of a passage of text
+// is prepared (similar to keydown for a keyboard input, but works with other
+// inputs such as speech recognition).
 //
 // https://developer.mozilla.org/docs/Web/Events/compositionstart
 func CompositionStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "compositionstart", Listener: listener}
 }
 
-// A character is added to a passage of text being composed.
+// CompositionUpdate is an event fired when a character is added to a passage
+// of text being composed.
 //
 // https://developer.mozilla.org/docs/Web/Events/compositionupdate
 func CompositionUpdate(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "compositionupdate", Listener: listener}
 }
 
-// The right button of the mouse is clicked (before the context menu is displayed).
+// ContextMenu is an event fired when the right button of the mouse is clicked
+// (before the context menu is displayed).
 //
 // https://developer.mozilla.org/docs/Web/Events/contextmenu
 func ContextMenu(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "contextmenu", Listener: listener}
 }
 
-// The text selection has been added to the clipboard.
+// Copy is an event fired when the text selection has been added to the
+// clipboard.
 //
 // https://developer.mozilla.org/docs/Web/Events/copy
 func Copy(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "copy", Listener: listener}
 }
 
-// The text selection has been removed from the document and added to the clipboard.
+// Cut is an event fired when the text selection has been removed from the
+// document and added to the clipboard.
 //
 // https://developer.mozilla.org/docs/Web/Events/cut
 func Cut(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "cut", Listener: listener}
 }
 
-// The document has finished loading (but not its dependent resources).
+// DOMContentLoaded is an event fired when the document has finished loading
+// (but not its dependent resources).
 //
 // https://developer.mozilla.org/docs/Web/Events/DOMContentLoaded
 func DOMContentLoaded(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "DOMContentLoaded", Listener: listener}
 }
 
-// Fresh data is available from a light sensor.
+// DeviceLight is an event fired when fresh data is available from a light
+// sensor.
 //
 // https://developer.mozilla.org/docs/Web/Events/devicelight
 func DeviceLight(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "devicelight", Listener: listener}
 }
 
-// Fresh data is available from a motion sensor.
+// DeviceMotion is an event fired when fresh data is available from a motion
+// sensor.
 //
 // https://developer.mozilla.org/docs/Web/Events/devicemotion
 func DeviceMotion(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "devicemotion", Listener: listener}
 }
 
-// Fresh data is available from an orientation sensor.
+// DeviceOrientation is an event fired when fresh data is available from an
+// orientation sensor.
 //
 // https://developer.mozilla.org/docs/Web/Events/deviceorientation
 func DeviceOrientation(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "deviceorientation", Listener: listener}
 }
 
-// Fresh data is available from a proximity sensor (indicates an approximated distance between the device and a nearby object).
+// DeviceProximity is an event fired when fresh data is available from a
+// proximity sensor (indicates an approximated distance between the device and
+// a nearby object).
 //
 // https://developer.mozilla.org/docs/Web/Events/deviceproximity
 func DeviceProximity(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "deviceproximity", Listener: listener}
 }
 
-// The dischargingTime attribute has been updated.
+// DischargingTimeChange is an event fired when the dischargingTime attribute
+// has been updated.
 //
 // https://developer.mozilla.org/docs/Web/Events/dischargingtimechange
 func DischargingTimeChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "dischargingtimechange", Listener: listener}
 }
 
-// A pointing device button is clicked twice on an element.
+// DoubleClick is an event fired when a pointing device button is clicked twice
+// on an element.
 //
 // https://developer.mozilla.org/docs/Web/Events/dblclick
 func DoubleClick(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "dblclick", Listener: listener}
 }
 
-// The user agent has found an update and is fetching it, or is downloading the resources listed by the cache manifest for the first time.
+// Downloading is an event fired when the user agent has found an update and is
+// fetching it, or is downloading the resources listed by the cache manifest
+// for the first time.
 //
 // https://developer.mozilla.org/docs/Web/Events/downloading
 func Downloading(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "downloading", Listener: listener}
 }
 
-// An element or text selection is being dragged (every 350ms).
+// Drag is an event fired when an element or text selection is being dragged
+// (every 350ms).
 //
 // https://developer.mozilla.org/docs/Web/Events/drag
 func Drag(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "drag", Listener: listener}
 }
 
-// A drag operation is being ended (by releasing a mouse button or hitting the escape key).
+// DragEnd is an event fired when a drag operation is being ended (by releasing
+// a mouse button or hitting the escape key).
 //
 // https://developer.mozilla.org/docs/Web/Events/dragend
 func DragEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "dragend", Listener: listener}
 }
 
-// A dragged element or text selection enters a valid drop target.
+// DragEnter is an event fired when a dragged element or text selection enters
+// a valid drop target.
 //
 // https://developer.mozilla.org/docs/Web/Events/dragenter
 func DragEnter(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "dragenter", Listener: listener}
 }
 
-// A dragged element or text selection leaves a valid drop target.
+// DragLeave is an event fired when a dragged element or text selection leaves
+// a valid drop target.
 //
 // https://developer.mozilla.org/docs/Web/Events/dragleave
 func DragLeave(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "dragleave", Listener: listener}
 }
 
-// An element or text selection is being dragged over a valid drop target (every 350ms).
+// DragOver is an event fired when an element or text selection is being
+// dragged over a valid drop target (every 350ms).
 //
 // https://developer.mozilla.org/docs/Web/Events/dragover
 func DragOver(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "dragover", Listener: listener}
 }
 
-// The user starts dragging an element or text selection.
+// DragStart is an event fired when the user starts dragging an element or text
+// selection.
 //
 // https://developer.mozilla.org/docs/Web/Events/dragstart
 func DragStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "dragstart", Listener: listener}
 }
 
-// An element is dropped on a valid drop target.
+// Drop is an event fired when an element is dropped on a valid drop target.
 //
 // https://developer.mozilla.org/docs/Web/Events/drop
 func Drop(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "drop", Listener: listener}
 }
 
-// The duration attribute has been updated.
+// DurationChange is an event fired when the duration attribute has been
+// updated.
 //
 // https://developer.mozilla.org/docs/Web/Events/durationchange
 func DurationChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "durationchange", Listener: listener}
 }
 
-// The media has become empty; for example, this event is sent if the media has already been loaded (or partially loaded), and the load() method is called to reload it.
+// Emptied is an event fired when the media has become empty; for example, this
+// event is sent if the media has already been loaded (or partially loaded),
+// and the load() method is called to reload it.
 //
 // https://developer.mozilla.org/docs/Web/Events/emptied
 func Emptied(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "emptied", Listener: listener}
 }
 
-// The utterance has finished being spoken.
+// End is an event fired when the utterance has finished being spoken.
 //
 // https://developer.mozilla.org/docs/Web/Events/end_(SpeechSynthesis)
 func End(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "end", Listener: listener}
 }
 
-// A SMIL animation element ends.
+// EndEvent is an event fired when a SMIL animation element ends.
 //
 // https://developer.mozilla.org/docs/Web/Events/endEvent
 func EndEvent(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "endEvent", Listener: listener}
 }
 
-// Playback has stopped because the end of the media was reached.
+// Ended is an event fired when playback has stopped because the end of the
+// media was reached.
 //
 // https://developer.mozilla.org/docs/Web/Events/ended_(Web_Audio)
 func Ended(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "ended", Listener: listener}
 }
 
-// An error occurs that prevents the utterance from being successfully spoken.
+// Error is an event fired when an error occurs that prevents the utterance
+// from being successfully spoken.
 //
 // https://developer.mozilla.org/docs/Web/Events/error_(SpeechSynthesisError)
 func Error(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "error", Listener: listener}
 }
 
-// An element has received focus (does not bubble).
+// Focus is an event fired when an element has received focus (does not
+// bubble).
 //
 // https://developer.mozilla.org/docs/Web/Events/focus
 func Focus(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "focus", Listener: listener}
 }
 
-// An element is about to receive focus (bubbles).
+// FocusIn is an event fired when an element is about to receive focus
+// (bubbles).
 //
 // https://developer.mozilla.org/docs/Web/Events/focusin
 func FocusIn(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "focusin", Listener: listener}
 }
 
-// An element is about to lose focus (bubbles).
+// FocusOut is an event fired when an element is about to lose focus (bubbles).
 //
 // https://developer.mozilla.org/docs/Web/Events/focusout
 func FocusOut(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "focusout", Listener: listener}
 }
 
-// An element was turned to fullscreen mode or back to normal mode.
+// FullScreenChange is an event fired when an element was turned to fullscreen
+// mode or back to normal mode.
 //
 // https://developer.mozilla.org/docs/Web/Events/fullscreenchange
 func FullScreenChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "fullscreenchange", Listener: listener}
 }
 
-// It was impossible to switch to fullscreen mode for technical reasons or because the permission was denied.
+// FullScreenError is an event fired when it was impossible to switch to
+// fullscreen mode for technical reasons or because the permission was denied.
 //
 // https://developer.mozilla.org/docs/Web/Events/fullscreenerror
 func FullScreenError(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "fullscreenerror", Listener: listener}
 }
 
-// A gamepad has been connected.
+// GamepadConnected is an event fired when a gamepad has been connected.
 //
 // https://developer.mozilla.org/docs/Web/Events/gamepadconnected
 func GamepadConnected(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "gamepadconnected", Listener: listener}
 }
 
-// A gamepad has been disconnected.
+// GamepadDisconnected is an event fired when a gamepad has been disconnected.
 //
 // https://developer.mozilla.org/docs/Web/Events/gamepaddisconnected
 func GamepadDisconnected(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "gamepaddisconnected", Listener: listener}
 }
 
-// Element receives pointer capture.
+// GotPointerCapture is an event fired when element receives pointer capture.
 //
 // https://developer.mozilla.org/docs/Web/Events/gotpointercapture
 func GotPointerCapture(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "gotpointercapture", Listener: listener}
 }
 
-// The fragment identifier of the URL has changed (the part of the URL after the #).
+// HashChange is an event fired when the fragment identifier of the URL has
+// changed (the part of the URL after the #).
 //
 // https://developer.mozilla.org/docs/Web/Events/hashchange
 func HashChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "hashchange", Listener: listener}
 }
 
-// The value of an element changes or the content of an element with the attribute contenteditable is modified.
+// Input is an event fired when the value of an element changes or the content
+// of an element with the attribute contenteditable is modified.
 //
 // https://developer.mozilla.org/docs/Web/Events/input
 func Input(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "input", Listener: listener}
 }
 
-// A submittable element has been checked and doesn't satisfy its constraints.
+// Invalid is an event fired when a submittable element has been checked and
+// doesn't satisfy its constraints.
 //
 // https://developer.mozilla.org/docs/Web/Events/invalid
 func Invalid(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "invalid", Listener: listener}
 }
 
-// A key is pressed down.
+// KeyDown is an event fired when a key is pressed down.
 //
 // https://developer.mozilla.org/docs/Web/Events/keydown
 func KeyDown(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "keydown", Listener: listener}
 }
 
-// A key is pressed down and that key normally produces a character value (use input instead).
+// KeyPress is an event fired when a key is pressed down and that key normally
+// produces a character value (use input instead).
 //
 // https://developer.mozilla.org/docs/Web/Events/keypress
 func KeyPress(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "keypress", Listener: listener}
 }
 
-// A key is released.
+// KeyUp is an event fired when a key is released.
 //
 // https://developer.mozilla.org/docs/Web/Events/keyup
 func KeyUp(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "keyup", Listener: listener}
 }
 
-// The user's preferred languages have changed.
+// LanguageChange is an event fired when the user's preferred languages have
+// changed.
 //
 // https://developer.mozilla.org/docs/Web/Events/languagechange
 func LanguageChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "languagechange", Listener: listener}
 }
 
-// The level attribute has been updated.
+// LevelChange is an event fired when the level attribute has been updated.
 //
 // https://developer.mozilla.org/docs/Web/Events/levelchange
 func LevelChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "levelchange", Listener: listener}
 }
 
-// Progression has been successful.
+// Load is an event fired when progression has been successful.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/load_(ProgressEvent)
 func Load(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "load", Listener: listener}
 }
 
-// Progress has stopped (after "error", "abort" or "load" have been dispatched).
+// LoadEnd is an event fired when progress has stopped (after "error", "abort"
+// or "load" have been dispatched).
 //
 // https://developer.mozilla.org/docs/Web/Events/loadend
 func LoadEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "loadend", Listener: listener}
 }
 
-// Progress has begun.
+// LoadStart is an event fired when progress has begun.
 //
 // https://developer.mozilla.org/docs/Web/Events/loadstart
 func LoadStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "loadstart", Listener: listener}
 }
 
-// The first frame of the media has finished loading.
+// LoadedData is an event fired when the first frame of the media has finished
+// loading.
 //
 // https://developer.mozilla.org/docs/Web/Events/loadeddata
 func LoadedData(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "loadeddata", Listener: listener}
 }
 
-// The metadata has been loaded.
+// LoadedMetadata is an event fired when the metadata has been loaded.
 //
 // https://developer.mozilla.org/docs/Web/Events/loadedmetadata
 func LoadedMetadata(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "loadedmetadata", Listener: listener}
 }
 
-// Element lost pointer capture.
+// LostPointerCapture is an event fired when element lost pointer capture.
 //
 // https://developer.mozilla.org/docs/Web/Events/lostpointercapture
 func LostPointerCapture(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "lostpointercapture", Listener: listener}
 }
 
-// The spoken utterance reaches a named SSML "mark" tag.
+// Mark is an event fired when the spoken utterance reaches a named SSML "mark"
+// tag.
 //
 // https://developer.mozilla.org/docs/Web/Events/mark
 func Mark(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mark", Listener: listener}
 }
 
-// A message is received from a service worker, or a message is received in a service worker from another context.
+// Message is an event fired when a message is received from a service worker,
+// or a message is received in a service worker from another context.
 //
 // https://developer.mozilla.org/docs/Web/Events/message_(ServiceWorker)
 func Message(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "message", Listener: listener}
 }
 
-// A pointing device button (usually a mouse) is pressed on an element.
+// MouseDown is an event fired when a pointing device button (usually a mouse)
+// is pressed on an element.
 //
 // https://developer.mozilla.org/docs/Web/Events/mousedown
 func MouseDown(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mousedown", Listener: listener}
 }
 
-// A pointing device is moved onto the element that has the listener attached.
+// MouseEnter is an event fired when a pointing device is moved onto the
+// element that has the listener attached.
 //
 // https://developer.mozilla.org/docs/Web/Events/mouseenter
 func MouseEnter(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mouseenter", Listener: listener}
 }
 
-// A pointing device is moved off the element that has the listener attached.
+// MouseLeave is an event fired when a pointing device is moved off the element
+// that has the listener attached.
 //
 // https://developer.mozilla.org/docs/Web/Events/mouseleave
 func MouseLeave(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mouseleave", Listener: listener}
 }
 
-// A pointing device is moved over an element.
+// MouseMove is an event fired when a pointing device is moved over an element.
 //
 // https://developer.mozilla.org/docs/Web/Events/mousemove
 func MouseMove(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mousemove", Listener: listener}
 }
 
-// A pointing device is moved off the element that has the listener attached or off one of its children.
+// MouseOut is an event fired when a pointing device is moved off the element
+// that has the listener attached or off one of its children.
 //
 // https://developer.mozilla.org/docs/Web/Events/mouseout
 func MouseOut(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mouseout", Listener: listener}
 }
 
-// A pointing device is moved onto the element that has the listener attached or onto one of its children.
+// MouseOver is an event fired when a pointing device is moved onto the element
+// that has the listener attached or onto one of its children.
 //
 // https://developer.mozilla.org/docs/Web/Events/mouseover
 func MouseOver(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mouseover", Listener: listener}
 }
 
-// A pointing device button is released over an element.
+// MouseUp is an event fired when a pointing device button is released over an
+// element.
 //
 // https://developer.mozilla.org/docs/Web/Events/mouseup
 func MouseUp(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "mouseup", Listener: listener}
 }
 
-// The speech recognition service returns a final result with no significant recognition.
+// NoMatch is an event fired when the speech recognition service returns a
+// final result with no significant recognition.
 //
 // https://developer.mozilla.org/docs/Web/Events/nomatch
 func NoMatch(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "nomatch", Listener: listener}
 }
 
-// The manifest hadn't changed.
+// NoUpdate is an event fired when the manifest hadn't changed.
 //
 // https://developer.mozilla.org/docs/Web/Events/noupdate
 func NoUpdate(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "noupdate", Listener: listener}
 }
 
-// A system notification spawned by ServiceWorkerRegistration.showNotification() has been clicked.
+// NotificationClick is an event fired when a system notification spawned by
+// ServiceWorkerRegistration.showNotification() has been clicked.
 //
 // https://developer.mozilla.org/docs/Web/Events/notificationclick
 func NotificationClick(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "notificationclick", Listener: listener}
 }
 
-// The manifest was found to have become a 404 or 410 page, so the application cache is being deleted.
+// Obsolete is an event fired when the manifest was found to have become a 404
+// or 410 page, so the application cache is being deleted.
 //
 // https://developer.mozilla.org/docs/Web/Events/obsolete
 func Obsolete(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "obsolete", Listener: listener}
 }
 
-// The browser has lost access to the network.
+// Offline is an event fired when the browser has lost access to the network.
 //
 // https://developer.mozilla.org/docs/Web/Events/offline
 func Offline(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "offline", Listener: listener}
 }
 
-// The browser has gained access to the network (but particular websites might be unreachable).
+// Online is an event fired when the browser has gained access to the network
+// (but particular websites might be unreachable).
 //
 // https://developer.mozilla.org/docs/Web/Events/online
 func Online(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "online", Listener: listener}
 }
 
-// An event source connection has been established.
+// Open is an event fired when an event source connection has been established.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/open_serversentevents
 func Open(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "open", Listener: listener}
 }
 
-// The orientation of the device (portrait/landscape) has changed
+// OrientationChange is an event fired when the orientation of the device
+// (portrait/landscape) has changed
 //
 // https://developer.mozilla.org/docs/Web/Events/orientationchange
 func OrientationChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "orientationchange", Listener: listener}
 }
 
-// A session history entry is being traversed from.
+// PageHide is an event fired when a session history entry is being traversed
+// from.
 //
 // https://developer.mozilla.org/docs/Web/Events/pagehide
 func PageHide(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pagehide", Listener: listener}
 }
 
-// A session history entry is being traversed to.
+// PageShow is an event fired when a session history entry is being traversed
+// to.
 //
 // https://developer.mozilla.org/docs/Web/Events/pageshow
 func PageShow(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pageshow", Listener: listener}
 }
 
-// Data has been transferred from the system clipboard to the document.
+// Paste is an event fired when data has been transferred from the system
+// clipboard to the document.
 //
 // https://developer.mozilla.org/docs/Web/Events/paste
 func Paste(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "paste", Listener: listener}
 }
 
-// The utterance is paused part way through.
+// Pause is an event fired when the utterance is paused part way through.
 //
 // https://developer.mozilla.org/docs/Web/Events/pause_(SpeechSynthesis)
 func Pause(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pause", Listener: listener}
 }
 
-// Playback has begun.
+// Play is an event fired when playback has begun.
 //
 // https://developer.mozilla.org/docs/Web/Events/play
 func Play(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "play", Listener: listener}
 }
 
-// Playback is ready to start after having been paused or delayed due to lack of data.
+// Playing is an event fired when playback is ready to start after having been
+// paused or delayed due to lack of data.
 //
 // https://developer.mozilla.org/docs/Web/Events/playing
 func Playing(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "playing", Listener: listener}
 }
 
-// The pointer is unlikely to produce any more events.
+// PointerCancel is an event fired when the pointer is unlikely to produce any
+// more events.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointercancel
 func PointerCancel(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointercancel", Listener: listener}
 }
 
-// The pointer enters the active buttons state.
+// PointerDown is an event fired when the pointer enters the active buttons
+// state.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerdown
 func PointerDown(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerdown", Listener: listener}
 }
 
-// Pointing device is moved inside the hit-testing boundary.
+// PointerEnter is an event fired when pointing device is moved inside the
+// hit-testing boundary.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerenter
 func PointerEnter(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerenter", Listener: listener}
 }
 
-// Pointing device is moved out of the hit-testing boundary.
+// PointerLeave is an event fired when pointing device is moved out of the
+// hit-testing boundary.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerleave
 func PointerLeave(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerleave", Listener: listener}
 }
 
-// The pointer was locked or released.
+// PointerLockChange is an event fired when the pointer was locked or released.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerlockchange
 func PointerLockChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerlockchange", Listener: listener}
 }
 
-// It was impossible to lock the pointer for technical reasons or because the permission was denied.
+// PointerLockError is an event fired when it was impossible to lock the
+// pointer for technical reasons or because the permission was denied.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerlockerror
 func PointerLockError(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerlockerror", Listener: listener}
 }
 
-// The pointer changed coordinates.
+// PointerMove is an event fired when the pointer changed coordinates.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointermove
 func PointerMove(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointermove", Listener: listener}
 }
 
-// The pointing device moved out of hit-testing boundary or leaves detectable hover range.
+// PointerOut is an event fired when the pointing device moved out of
+// hit-testing boundary or leaves detectable hover range.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerout
 func PointerOut(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerout", Listener: listener}
 }
 
-// The pointing device is moved into the hit-testing boundary.
+// PointerOver is an event fired when the pointing device is moved into the
+// hit-testing boundary.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerover
 func PointerOver(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerover", Listener: listener}
 }
 
-// The pointer leaves the active buttons state.
+// PointerUp is an event fired when the pointer leaves the active buttons
+// state.
 //
 // https://developer.mozilla.org/docs/Web/Events/pointerup
 func PointerUp(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pointerup", Listener: listener}
 }
 
-// A session history entry is being navigated to (in certain cases).
+// PopState is an event fired when a session history entry is being navigated
+// to (in certain cases).
 //
 // https://developer.mozilla.org/docs/Web/Events/popstate
 func PopState(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "popstate", Listener: listener}
 }
 
-// The user agent is downloading resources listed by the manifest.
+// Progress is an event fired when the user agent is downloading resources
+// listed by the manifest.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/progress_(appcache_event)
 func Progress(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "progress", Listener: listener}
 }
 
-// A Service Worker has received a push message.
+// Push is an event fired when a Service Worker has received a push message.
 //
 // https://developer.mozilla.org/docs/Web/Events/push
 func Push(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "push", Listener: listener}
 }
 
-// A PushSubscription has expired.
+// PushSubscriptionChange is an event fired when a PushSubscription has
+// expired.
 //
 // https://developer.mozilla.org/docs/Web/Events/pushsubscriptionchange
 func PushSubscriptionChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "pushsubscriptionchange", Listener: listener}
 }
 
-// The playback rate has changed.
+// RateChange is an event fired when the playback rate has changed.
 //
 // https://developer.mozilla.org/docs/Web/Events/ratechange
 func RateChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "ratechange", Listener: listener}
 }
 
-// The readyState attribute of a document has changed.
+// ReadyStateChange is an event fired when the readyState attribute of a
+// document has changed.
 //
 // https://developer.mozilla.org/docs/Web/Events/readystatechange
 func ReadyStateChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "readystatechange", Listener: listener}
 }
 
-// A SMIL animation element is repeated.
+// RepeatEvent is an event fired when a SMIL animation element is repeated.
 //
 // https://developer.mozilla.org/docs/Web/Events/repeatEvent
 func RepeatEvent(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "repeatEvent", Listener: listener}
 }
 
-// A form is reset.
+// Reset is an event fired when a form is reset.
 //
 // https://developer.mozilla.org/docs/Web/Events/reset
 func Reset(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "reset", Listener: listener}
 }
 
-// The document view has been resized.
+// Resize is an event fired when the document view has been resized.
 //
 // https://developer.mozilla.org/docs/Web/Events/resize
 func Resize(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "resize", Listener: listener}
 }
 
-// The browser's resource timing buffer is full.
+// ResourceTimingBufferFull is an event fired when the browser's resource
+// timing buffer is full.
 //
 // https://developer.mozilla.org/docs/Web/Events/resourcetimingbufferfull
 func ResourceTimingBufferFull(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "resourcetimingbufferfull", Listener: listener}
 }
 
-// The speech recognition service returns a result — a word or phrase has been positively recognized and this has been communicated back to the app.
+// Result is an event fired when the speech recognition service returns a
+// result — a word or phrase has been positively recognized and this has been
+// communicated back to the app.
 //
 // https://developer.mozilla.org/docs/Web/Events/result
 func Result(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "result", Listener: listener}
 }
 
-// A paused utterance is resumed.
+// Resume is an event fired when a paused utterance is resumed.
 //
 // https://developer.mozilla.org/docs/Web/Events/resume
 func Resume(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "resume", Listener: listener}
 }
 
-// Page loading has been stopped before the SVG was loaded.
+// SVGAbort is an event fired when page loading has been stopped before the SVG
+// was loaded.
 //
 // https://developer.mozilla.org/docs/Web/Events/SVGAbort
 func SVGAbort(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "SVGAbort", Listener: listener}
 }
 
-// An error has occurred before the SVG was loaded.
+// SVGError is an event fired when an error has occurred before the SVG was
+// loaded.
 //
 // https://developer.mozilla.org/docs/Web/Events/SVGError
 func SVGError(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "SVGError", Listener: listener}
 }
 
-// An SVG document has been loaded and parsed.
+// SVGLoad is an event fired when an SVG document has been loaded and parsed.
 //
 // https://developer.mozilla.org/docs/Web/Events/SVGLoad
 func SVGLoad(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "SVGLoad", Listener: listener}
 }
 
-// An SVG document is being resized.
+// SVGResize is an event fired when an SVG document is being resized.
 //
 // https://developer.mozilla.org/docs/Web/Events/SVGResize
 func SVGResize(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "SVGResize", Listener: listener}
 }
 
-// An SVG document is being scrolled.
+// SVGScroll is an event fired when an SVG document is being scrolled.
 //
 // https://developer.mozilla.org/docs/Web/Events/SVGScroll
 func SVGScroll(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "SVGScroll", Listener: listener}
 }
 
-// An SVG document has been removed from a window or frame.
+// SVGUnload is an event fired when an SVG document has been removed from a
+// window or frame.
 //
 // https://developer.mozilla.org/docs/Web/Events/SVGUnload
 func SVGUnload(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "SVGUnload", Listener: listener}
 }
 
-// An SVG document is being zoomed.
+// SVGZoom is an event fired when an SVG document is being zoomed.
 //
 // https://developer.mozilla.org/docs/Web/Events/SVGZoom
 func SVGZoom(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "SVGZoom", Listener: listener}
 }
 
-// The document view or an element has been scrolled.
+// Scroll is an event fired when the document view or an element has been
+// scrolled.
 //
 // https://developer.mozilla.org/docs/Web/Events/scroll
 func Scroll(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "scroll", Listener: listener}
 }
 
-// A seek operation completed.
+// Seeked is an event fired when a seek operation completed.
 //
 // https://developer.mozilla.org/docs/Web/Events/seeked
 func Seeked(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "seeked", Listener: listener}
 }
 
-// A seek operation began.
+// Seeking is an event fired when a seek operation began.
 //
 // https://developer.mozilla.org/docs/Web/Events/seeking
 func Seeking(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "seeking", Listener: listener}
 }
 
-// Some text is being selected.
+// Select is an event fired when some text is being selected.
 //
 // https://developer.mozilla.org/docs/Web/Events/select
 func Select(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "select", Listener: listener}
 }
 
-// A selection just started.
+// SelectStart is an event fired when a selection just started.
 //
 // https://developer.mozilla.org/docs/Web/Events/selectstart
 func SelectStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "selectstart", Listener: listener}
 }
 
-// The selection in the document has been changed.
+// SelectionChange is an event fired when the selection in the document has
+// been changed.
 //
 // https://developer.mozilla.org/docs/Web/Events/selectionchange
 func SelectionChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "selectionchange", Listener: listener}
 }
 
-// A contextmenu event was fired on/bubbled to an element that has a contextmenu attribute
+// Show is an event fired when a contextmenu event was fired on/bubbled to an
+// element that has a contextmenu attribute
 //
 // https://developer.mozilla.org/docs/Web/Events/show
 func Show(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "show", Listener: listener}
 }
 
-// Any sound — recognisable speech or not — has stopped being detected.
+// SoundEnd is an event fired when any sound — recognisable speech or not —
+// has stopped being detected.
 //
 // https://developer.mozilla.org/docs/Web/Events/soundend
 func SoundEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "soundend", Listener: listener}
 }
 
-// Any sound — recognisable speech or not — has been detected.
+// SoundStart is an event fired when any sound — recognisable speech or not
+// — has been detected.
 //
 // https://developer.mozilla.org/docs/Web/Events/soundstart
 func SoundStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "soundstart", Listener: listener}
 }
 
-// Speech recognised by the speech recognition service has stopped being detected.
+// SpeechEnd is an event fired when speech recognised by the speech recognition
+// service has stopped being detected.
 //
 // https://developer.mozilla.org/docs/Web/Events/speechend
 func SpeechEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "speechend", Listener: listener}
 }
 
-// Sound that is recognised by the speech recognition service as speech has been detected.
+// SpeechStart is an event fired when sound that is recognised by the speech
+// recognition service as speech has been detected.
 //
 // https://developer.mozilla.org/docs/Web/Events/speechstart
 func SpeechStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "speechstart", Listener: listener}
 }
 
-// The user agent is trying to fetch media data, but data is unexpectedly not forthcoming.
+// Stalled is an event fired when the user agent is trying to fetch media data,
+// but data is unexpectedly not forthcoming.
 //
 // https://developer.mozilla.org/docs/Web/Events/stalled
 func Stalled(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "stalled", Listener: listener}
 }
 
-// The utterance has begun to be spoken.
+// Start is an event fired when the utterance has begun to be spoken.
 //
 // https://developer.mozilla.org/docs/Web/Events/start_(SpeechSynthesis)
 func Start(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "start", Listener: listener}
 }
 
-// A storage area (localStorage or sessionStorage) has changed.
+// Storage is an event fired when a storage area (localStorage or
+// sessionStorage) has changed.
 //
 // https://developer.mozilla.org/docs/Web/Events/storage
 func Storage(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "storage", Listener: listener}
 }
 
-// A form is submitted.
+// Submit is an event fired when a form is submitted.
 //
 // https://developer.mozilla.org/docs/Web/Events/submit
 func Submit(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "submit", Listener: listener}
 }
 
-// A request successfully completed.
+// Success is an event fired when a request successfully completed.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/success_indexedDB
 func Success(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "success", Listener: listener}
 }
 
-// Media data loading has been suspended.
+// Suspend is an event fired when media data loading has been suspended.
 //
 // https://developer.mozilla.org/docs/Web/Events/suspend
 func Suspend(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "suspend", Listener: listener}
 }
 
-// The time indicated by the currentTime attribute has been updated.
+// TimeUpdate is an event fired when the time indicated by the currentTime
+// attribute has been updated.
 //
 // https://developer.mozilla.org/docs/Web/Events/timeupdate
 func TimeUpdate(listener func(*vecty.Event)) *vecty.EventListener {
@@ -1015,126 +1120,121 @@ func Timeout(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "timeout", Listener: listener}
 }
 
-// A touch point has been disrupted in an implementation-specific manners (too many touch points for example).
+// TouchCancel is an event fired when a touch point has been disrupted in an
+// implementation-specific manners (too many touch points for example).
 //
 // https://developer.mozilla.org/docs/Web/Events/touchcancel
 func TouchCancel(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "touchcancel", Listener: listener}
 }
 
-// A touch point is removed from the touch surface.
+// TouchEnd is an event fired when a touch point is removed from the touch
+// surface.
 //
 // https://developer.mozilla.org/docs/Web/Events/touchend
 func TouchEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "touchend", Listener: listener}
 }
 
-// A touch point is moved along the touch surface.
+// TouchMove is an event fired when a touch point is moved along the touch
+// surface.
 //
 // https://developer.mozilla.org/docs/Web/Events/touchmove
 func TouchMove(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "touchmove", Listener: listener}
 }
 
-// A touch point is placed on the touch surface.
+// TouchStart is an event fired when a touch point is placed on the touch
+// surface.
 //
 // https://developer.mozilla.org/docs/Web/Events/touchstart
 func TouchStart(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "touchstart", Listener: listener}
 }
 
-// A CSS transition has completed.
+// TransitionEnd is an event fired when a CSS transition has completed.
 //
 // https://developer.mozilla.org/docs/Web/Events/transitionend
 func TransitionEnd(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "transitionend", Listener: listener}
 }
 
-// The document or a dependent resource is being unloaded.
+// Unload is an event fired when the document or a dependent resource is being
+// unloaded.
 //
 // https://developer.mozilla.org/docs/Web/Events/unload
 func Unload(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "unload", Listener: listener}
 }
 
-// The resources listed in the manifest have been newly redownloaded, and the script can use swapCache() to switch to the new cache.
+// UpdateReady is an event fired when the resources listed in the manifest have
+// been newly redownloaded, and the script can use swapCache() to switch to the
+// new cache.
 //
 // https://developer.mozilla.org/docs/Web/Events/updateready
 func UpdateReady(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "updateready", Listener: listener}
 }
 
-// An attempt was made to open a database with a version number higher than its current version. A versionchange transaction has been created.
+// UpgradeNeeded is an event fired when an attempt was made to open a database
+// with a version number higher than its current version. A versionchange
+// transaction has been created.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/upgradeneeded_indexedDB
 func UpgradeNeeded(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "upgradeneeded", Listener: listener}
 }
 
-// Fresh data is available from a proximity sensor (indicates whether the nearby object is near the device or not).
+// UserProximity is an event fired when fresh data is available from a
+// proximity sensor (indicates whether the nearby object is near the device or
+// not).
 //
 // https://developer.mozilla.org/docs/Web/Events/userproximity
 func UserProximity(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "userproximity", Listener: listener}
 }
 
-// A compatible VR device has been connected to the computer.
-//
-// https://developer.mozilla.org/docs/Web/Events/vrdisplayconnected
-func VRDisplayConnected(listener func(*vecty.Event)) *vecty.EventListener {
-	return &vecty.EventListener{Name: "vrdisplayconnected", Listener: listener}
-}
-
-// A compatible VR device has been disconnected from the computer.
-//
-// https://developer.mozilla.org/docs/Web/Events/vrdisplaydisconnected
-func VRDisplayDisconnected(listener func(*vecty.Event)) *vecty.EventListener {
-	return &vecty.EventListener{Name: "vrdisplaydisconnected", Listener: listener}
-}
-
-// The presenting state of a VR device has changed — i.e. from presenting to not presenting, or vice versa.
-//
-// https://developer.mozilla.org/docs/Web/Events/vrdisplaypresentchange
-func VRDisplayPresentChange(listener func(*vecty.Event)) *vecty.EventListener {
-	return &vecty.EventListener{Name: "vrdisplaypresentchange", Listener: listener}
-}
-
-// A versionchange transaction completed.
+// VersionChange is an event fired when a versionchange transaction completed.
 //
 // https://developer.mozilla.org/docs/Web/Reference/Events/versionchange_indexedDB
 func VersionChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "versionchange", Listener: listener}
 }
 
-// The content of a tab has become visible or has been hidden.
+// VisibilityChange is an event fired when the content of a tab has become
+// visible or has been hidden.
 //
 // https://developer.mozilla.org/docs/Web/Events/visibilitychange
 func VisibilityChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "visibilitychange", Listener: listener}
 }
 
-// The list of SpeechSynthesisVoice objects that would be returned by the SpeechSynthesis.getVoices() method has changed (when the voiceschanged event fires.)
+// VoicesChanged is an event fired when the list of SpeechSynthesisVoice
+// objects that would be returned by the SpeechSynthesis.getVoices() method has
+// changed (when the voiceschanged event fires.)
 //
 // https://developer.mozilla.org/docs/Web/Events/voiceschanged
 func VoicesChanged(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "voiceschanged", Listener: listener}
 }
 
-// The volume has changed.
+// VolumeChange is an event fired when the volume has changed.
 //
 // https://developer.mozilla.org/docs/Web/Events/volumechange
 func VolumeChange(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "volumechange", Listener: listener}
 }
 
-// Playback has stopped because of a temporary lack of data.
+// Waiting is an event fired when playback has stopped because of a temporary
+// lack of data.
 //
 // https://developer.mozilla.org/docs/Web/Events/waiting
 func Waiting(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "waiting", Listener: listener}
 }
 
-// A wheel button of a pointing device is rotated in any direction.
+// Wheel is an event fired when a wheel button of a pointing device is rotated
+// in any direction.
 //
 // https://developer.mozilla.org/docs/Web/Events/wheel
 func Wheel(listener func(*vecty.Event)) *vecty.EventListener {

--- a/event/generate.go
+++ b/event/generate.go
@@ -19,6 +19,12 @@ type Event struct {
 }
 
 func main() {
+	// nameMap translates lowercase HTML attribute names from the MDN source
+	// into a proper Go style name with MixedCaps and initialisms:
+	//
+	//  https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps
+	//  https://github.com/golang/go/wiki/CodeReviewComments#initialisms
+	//
 	nameMap := map[string]string{
 		"afterprint":               "AfterPrint",
 		"animationend":             "AnimationEnd",

--- a/event/generate.go
+++ b/event/generate.go
@@ -153,9 +153,7 @@ func main() {
 		}
 
 		if e.Desc != "" {
-			// Lowercase the first letter of the description.
-			lowercaseDesc := strings.ToLower(string(e.Desc[0])) + e.Desc[1:]
-			e.Desc = fmt.Sprintf("%s is an event fired when %s", funName, lowercaseDesc)
+			e.Desc = fmt.Sprintf("%s is an event fired when %s", funName, lowercase(e.Desc))
 		} else {
 			e.Desc = "(no documentation)"
 		}
@@ -203,6 +201,10 @@ func %s(listener func(*vecty.Event)) *vecty.EventListener {
 
 func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func lowercase(s string) string {
+	return strings.ToLower(s[:1]) + s[1:]
 }
 
 func descToComments(desc string) string {

--- a/event/generate.go
+++ b/event/generate.go
@@ -139,9 +139,6 @@ func main() {
 		e.Name = link.Text()
 		e.Link, _ = link.Attr("href")
 		e.Desc = strings.TrimSpace(cols.Eq(3).Text())
-		if e.Desc == "" {
-			e.Desc = "(no documentation)"
-		}
 		e.Spec = strings.TrimSpace(cols.Eq(2).Text())
 
 		funName := nameMap[e.Name]
@@ -149,6 +146,13 @@ func main() {
 			funName = capitalize(e.Name)
 		}
 
+		if e.Desc != "" {
+			// Lowercase the first letter of the description.
+			lowercaseDesc := strings.ToLower(string(e.Desc[0])) + e.Desc[1:]
+			e.Desc = fmt.Sprintf("%s is an event fired when %s", funName, lowercaseDesc)
+		} else {
+			e.Desc = "(no documentation)"
+		}
 		events[funName] = &e
 	})
 

--- a/event/generate.go
+++ b/event/generate.go
@@ -15,6 +15,7 @@ type Event struct {
 	Name string
 	Link string
 	Desc string
+	Spec string
 }
 
 func main() {
@@ -141,6 +142,7 @@ func main() {
 		if e.Desc == "" {
 			e.Desc = "(no documentation)"
 		}
+		e.Spec = strings.TrimSpace(cols.Eq(2).Text())
 
 		funName := nameMap[e.Name]
 		if funName == "" {
@@ -166,7 +168,9 @@ func main() {
 
 // Package event defines markup to bind DOM events.
 //
-// Generated from "Event reference" by Mozilla Contributors, https://developer.mozilla.org/en-US/docs/Web/Events, licensed under CC-BY-SA 2.5.
+// Generated from "Event reference" by Mozilla Contributors,
+// https://developer.mozilla.org/en-US/docs/Web/Events, licensed under
+// CC-BY-SA 2.5.
 package event
 
 import "github.com/gopherjs/vecty"
@@ -174,17 +178,33 @@ import "github.com/gopherjs/vecty"
 
 	for _, name := range names {
 		e := events[name]
-		fmt.Fprintf(file, `
-// %s
+		if e.Spec == "WebVR API" {
+			continue // not stabilized
+		}
+		fmt.Fprintf(file, `%s
 //
 // https://developer.mozilla.org%s
 func %s(listener func(*vecty.Event)) *vecty.EventListener {
 	return &vecty.EventListener{Name: "%s", Listener: listener}
 }
-`, e.Desc, e.Link[6:], name, e.Name)
+`, descToComments(e.Desc), e.Link[6:], name, e.Name)
 	}
 }
 
 func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func descToComments(desc string) string {
+	c := ""
+	length := 80
+	for _, word := range strings.Split(desc, " ") {
+		if length+len(word)+1 > 80 {
+			length = 3
+			c += "\n//"
+		}
+		c += " " + word
+		length += len(word) + 1
+	}
+	return c
 }


### PR DESCRIPTION
- Keep comments in both `event` and `elem` packages at readable lengths (wrap at 80 chars).
- Start func docstrings with the func name itself (following Go style conventions).
- Document name mapping properly (/cc @shurcooL).
