### PR TITLE
Support text nodes with an empty string

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -178,7 +178,7 @@ func (h *HTML) Restore(old ComponentOrHTML) {
 	}
 	if h.tag != "" {
 		h.Node = js.Global.Get("document").Call("createElement", h.tag)
-	} else if h.text != "" {
+	} else {
 		h.Node = js.Global.Get("document").Call("createTextNode", h.text)
 	}
 	for name, value := range h.properties {


### PR DESCRIPTION
Should we support text nodes with an empty string? I had an empty text node that was causing problems... 