### PR TITLE
Better support for nil in apply

### DIFF
--- a/markup.go
+++ b/markup.go
@@ -64,6 +64,9 @@ func apply(m MarkupOrComponentOrHTML, h *HTML) {
 	case Component:
 		h.children = append(h.children, m)
 	case *HTML:
+		if m == nil {
+			return
+		}
 		h.children = append(h.children, m)
 	default:
 		panic(fmt.Sprintf("vecty: invalid type %T does not match MarkupOrComponent interface", m))


### PR DESCRIPTION
If `m` is a `(*HTML)(nil)` then the first nil check will fail. This adds another after the cast to *HTML.