### PR TITLE
Defer doRender until after value of prevRender is taken

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -130,8 +130,8 @@ func (h *HTML) restoreHTML(prev *HTML) {
 
 	// TODO better list element reuse
 	for i, nextChild := range h.children {
-		nextChildRender := doRender(nextChild)
 		if i >= len(prev.children) {
+			nextChildRender := doRender(nextChild)
 			if doRestore(nil, nextChild, nil, nextChildRender) {
 				continue
 			}
@@ -143,6 +143,7 @@ func (h *HTML) restoreHTML(prev *HTML) {
 		if !ok {
 			prevChildRender = prevChild.(Component).Context().prevRender
 		}
+		nextChildRender := doRender(nextChild)
 		if doRestore(prevChild, nextChild, prevChildRender, nextChildRender) {
 			continue
 		}


### PR DESCRIPTION
Hey @slimsag one more bug... if h.children[i] == prev.children[i], then doRender will reset the prevRender of prevChild, and prevRender.Node will be nil.

This fixes it by deferring doRender until after we've taken the value of prevRender.

However, this worries me... What happens if the list order is mixed up and doRender clears the prevRender.Node of a component somewhere later in the prev children... Perhaps we need to read the prevRender values from all the children before doing any doRenders? I'll try to set up this situation to double check it's an issue.