### PR TITLE
Now it can deal with multiple style property values to allow vendor-prefixed values

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -2,6 +2,7 @@ package vecty
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -80,6 +81,7 @@ type HTML struct {
 	Node *js.Object
 
 	tag, text, innerHTML   string
+	classes                map[string]bool
 	styles                 map[string]map[string]bool
 	dataset                map[string]string
 	properties, attributes map[string]interface{}
@@ -131,6 +133,8 @@ func (h *HTML) restoreHTML(prev *HTML) {
 			h.Node.Call("removeAttribute", name)
 		}
 	}
+
+	h.populateClassNameProperty()
 
 	// Styles
 	style := h.Node.Get("style")
@@ -258,6 +262,7 @@ func (h *HTML) Restore(old ComponentOrHTML) {
 	for name, value := range h.dataset {
 		dataset.Set(name, value)
 	}
+	h.populateClassNameProperty()
 	style := h.Node.Get("style")
 	for name, value := range h.styles {
 		for value, _ := range value {
@@ -279,6 +284,18 @@ func (h *HTML) Restore(old ComponentOrHTML) {
 			continue
 		}
 		h.Node.Call("appendChild", nextChildRender.Node)
+	}
+}
+
+func (h *HTML) populateClassNameProperty() {
+	var classes []string
+	for class, set := range h.classes {
+		if set {
+			classes = append(classes, class)
+		}
+	}
+	if len(classes) > 0 {
+		h.Node.Set("className", strings.Join(classes, " "))
 	}
 }
 

--- a/dom.go
+++ b/dom.go
@@ -299,6 +299,14 @@ func (h *HTML) populateClassNameProperty() {
 	}
 }
 
+func (h *HTML) Add(m ...MarkupOrComponentOrHTML) *HTML {
+	for _, m := range m {
+		apply(m, h)
+	}
+
+	return h
+}
+
 // Tag returns an HTML element with the given tag name. Generally, this
 // function is not used directly but rather the elem subpackage (which is type
 // safe) is used instead.

--- a/markup.go
+++ b/markup.go
@@ -91,9 +91,12 @@ func (m markupFunc) Apply(h *HTML) { m(h) }
 func Style(key, value string) Markup {
 	return markupFunc(func(h *HTML) {
 		if h.styles == nil {
-			h.styles = make(map[string]string)
+			h.styles = make(map[string]map[string]bool)
 		}
-		h.styles[key] = value
+		if h.styles[key] == nil {
+			h.styles[key] = make(map[string]bool)
+		}
+		h.styles[key][value] = true
 	})
 }
 

--- a/markup.go
+++ b/markup.go
@@ -2,7 +2,6 @@ package vecty
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -144,13 +143,24 @@ type ClassMap map[string]bool
 
 // Apply implements the Markup interface.
 func (m ClassMap) Apply(h *HTML) {
-	var classes []string
-	for name, active := range m {
-		if active {
-			classes = append(classes, name)
-		}
+	if h.classes == nil {
+		h.classes = make(map[string]bool)
 	}
-	Property("className", strings.Join(classes, " ")).Apply(h)
+	for name, active := range m {
+		h.classes[name] = active
+	}
+}
+
+// Class returns markup that applies all given classes to an element
+func Class(classes ...string) Markup {
+	return markupFunc(func(h *HTML) {
+		if h.classes == nil {
+			h.classes = make(map[string]bool)
+		}
+		for _, name := range classes {
+			h.classes[name] = true
+		}
+	})
 }
 
 // List represents a list of Markup, Component, or HTML which is individually


### PR DESCRIPTION
How styles handling implemented now makes impossible to use vendor-prefixed property values.

For example
```go
elem.Div(
	vecty.Style("display", "-ms-flexbox"),
	vecty.Style("display", "-webkit-box"),
	vecty.Style("display", "-moz-box"),
	vecty.Style("display", "-ms-box"),
	vecty.Style("display", "box"),
)
```
will try to set only `display: box`.

If we want to completely eliminate necessity of writing CSS files we need to handle such cases, 'cause CSS prefixes is very common.