### PR TITLE
Fix wrong interface name in panic message.

### DIFF
--- a/markup.go
+++ b/markup.go
@@ -70,7 +70,7 @@ func apply(m MarkupOrComponentOrHTML, h *HTML) {
 		}
 		h.children = append(h.children, m)
 	default:
-		panic(fmt.Sprintf("vecty: invalid type %T does not match MarkupOrComponent interface", m))
+		panic(fmt.Sprintf("vecty: invalid type %T does not match MarkupOrComponentOrHTML interface", m))
 	}
 }
 


### PR DESCRIPTION
Seeing the reference to MarkupOrComponent interface made me look for it,
but it doesn't exist. It's just a typo, originally introduced in 6d402b7baf023b2977854d6345400713ff82fcde. /cc @slimsag