### PR TITLE
Use canonical format for build constraint.

### DIFF
--- a/gopherjs_only.go
+++ b/gopherjs_only.go
@@ -1,4 +1,4 @@
-//+build !js
+// +build !js
 
 package vecty
 


### PR DESCRIPTION
This improves consistency.

See https://godoc.org/go/build#hdr-Build_Constraints for definition of a build constraint:

> A build constraint, also known as a build tag, is a line comment that begins
>
>     // +build