### PR TITLE
Disallow Property("style", ...).

### DIFF
--- a/markup.go
+++ b/markup.go
@@ -87,7 +87,7 @@ func (m markupFunc) Apply(h *HTML) { m(h) }
 
 // Style returns Markup which applies the given CSS style. Generally, this
 // function is not used directly but rather the style subpackage (which is type
-// safe) is used instead.
+// safe) should be used instead.
 func Style(key, value string) Markup {
 	return markupFunc(func(h *HTML) {
 		if h.styles == nil {
@@ -99,8 +99,13 @@ func Style(key, value string) Markup {
 
 // Property returns Markup which applies the given JavaScript property to an
 // HTML element or text node. Generally, this function is not used directly but
-// rather the style subpackage (which is type safe) is used instead.
+// rather the prop and style subpackages (which are type safe) should be used instead.
+//
+// To set style, use style package or Style. Property panics if key is "style".
 func Property(key string, value interface{}) Markup {
+	if key == "style" {
+		panic(`vecty: Property called with key "style"; style package or Style should be used instead`)
+	}
 	return markupFunc(func(h *HTML) {
 		if h.properties == nil {
 			h.properties = make(map[string]interface{})


### PR DESCRIPTION
Update documentation to point out that [`style`](https://godoc.org/github.com/gopherjs/vecty/style) package or [`Style`](https://godoc.org/github.com/gopherjs/vecty#Style) should be used instead. Panic in `Property` if passed key "style".

Also update documentation of `Property` to point out both `prop` and `style` packages that are preferable. This was mentioned in https://github.com/gopherjs/vecty/issues/90#issuecomment-282601552.

Fixes #90.

This is what it looks like if the user breaks the API contract:

![image](https://cloud.githubusercontent.com/assets/1924134/24420040/65b346b2-13bf-11e7-8856-d3512e9a313d.png)