### PR TITLE
Add .travis.yml for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: go
+go:
+  - 1.8.x
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...


### PR DESCRIPTION
Don't try to build on `master`, because this package is expected to use GopherJS compiler, which only supports current version of Go.

Someone with admin access to this repository will still need to enable it at [travis-ci.org](https://travis-ci.org), then this `.travis.yml` configuration file will take effect. /cc @slimsag

Fixes #95.