### PR TITLE
event: Use single space between sentences.

### DIFF
--- a/event/generate.go
+++ b/event/generate.go
@@ -210,7 +210,7 @@ func lowercase(s string) string {
 func descToComments(desc string) string {
 	c := ""
 	length := 80
-	for _, word := range strings.Split(desc, " ") {
+	for _, word := range strings.Fields(desc) {
 		if length+len(word)+1 > 80 {
 			length = 3
 			c += "\n//"


### PR DESCRIPTION
(See https://github.com/gopherjs/vecty/pull/98#issuecomment-289865568 for context.)

Update generator to match similar change done in #98 for `elem` package.

There is no diff in the generated output, because the current input did not happen to have any double spaces or gofmt issues.

Helps keep code in sync.

Follows #98.