### PR TITLE
README: Add Travis CI and godoc badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Vecty is a [React](https://facebook.github.io/react/)-like library for [GopherJS](https://github.com/gopherjs/gopherjs) so that you can do frontend development in Go instead of writing JavaScript/HTML/CSS.
 
+[![Build Status](https://travis-ci.org/gopherjs/vecty.svg?branch=master)](https://travis-ci.org/gopherjs/vecty) [![GoDoc](https://godoc.org/github.com/gopherjs/vecty?status.svg)](https://godoc.org/github.com/gopherjs/vecty)
+
 Features
 ========
 


### PR DESCRIPTION
Now that #95 is resolved, it makes sense to display CI results.

Also add godoc badge for convenience of getting to godoc page. Most Go packages include one in the README.

Might want to hold off merging this until #101 is resolved.

### Preview

![image](https://cloud.githubusercontent.com/assets/1924134/24423213/3dd34010-13ca-11e7-8fe9-95f2ac48a5ec.png)