### PR TITLE
Add support for namespaced elements

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -79,11 +79,11 @@ type Restorer interface {
 type HTML struct {
 	Node *js.Object
 
-	tag, text, innerHTML   string
-	styles, dataset        map[string]string
-	properties, attributes map[string]interface{}
-	eventListeners         []*EventListener
-	children               []ComponentOrHTML
+	namespace, tag, text, innerHTML string
+	styles, dataset                 map[string]string
+	properties, attributes          map[string]interface{}
+	eventListeners                  []*EventListener
+	children                        []ComponentOrHTML
 }
 
 func (h *HTML) restoreText(prev *HTML) {
@@ -224,9 +224,12 @@ func (h *HTML) Restore(old ComponentOrHTML) {
 	if h.text != "" && h.innerHTML != "" {
 		panic("vecty: only HTML may have UnsafeHTML attribute")
 	}
-	if h.tag != "" {
+	switch {
+	case h.tag != "" && h.namespace == "":
 		h.Node = js.Global.Get("document").Call("createElement", h.tag)
-	} else {
+	case h.tag != "" && h.namespace != "":
+		h.Node = js.Global.Get("document").Call("createElementNS", h.namespace, h.tag)
+	default:
 		h.Node = js.Global.Get("document").Call("createTextNode", h.text)
 	}
 	if h.innerHTML != "" {
@@ -268,8 +271,16 @@ func (h *HTML) Restore(old ComponentOrHTML) {
 // function is not used directly but rather the elem subpackage (which is type
 // safe) is used instead.
 func Tag(tag string, m ...MarkupOrComponentOrHTML) *HTML {
+	return NamespacedTag("", tag, m...)
+}
+
+// NamespacedTag returns an HTML element with the given tag name, and namespace.
+// Generally, this function is not used directly but rather the elem subpackage
+// (which is type safe) is used instead.
+func NamespacedTag(namespace, tag string, m ...MarkupOrComponentOrHTML) *HTML {
 	h := &HTML{
-		tag: tag,
+		namespace: namespace,
+		tag:       tag,
 	}
 	for _, m := range m {
 		apply(m, h)


### PR DESCRIPTION
This allows the creation of elements like inline SVG.

Refs #54

Implementing full SVG support is a much more complex beast - that would require generating a new set of elements and properties for SVGs, and possibly some new interfaces to ensure they're only used inside an SVG element.

This change will support attempts at implementing the above, but in the mean time it allows people to construct SVGs manually using `vecty.NamespacedTag` and `vecty.Attribute`.