### PR TITLE
enable mocking JS calls for testing Vecty

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ Community
 =========
 
 - Join us in the [#gopherjs](https://gophers.slack.com/messages/gopherjs/) and [#vecty](https://gophers.slack.com/messages/vecty/) channels on the [Gophers Slack](https://gophersinvite.herokuapp.com/)!
+
+Changelog
+=========
+
+See the [docs/CHANGELOG.md](docs/CHANGELOG.md) file.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,9 @@
+Changelog
+=========
+
+Although v1.0.0 [is not yet out](https://github.com/gopherjs/vecty/milestone/1), we do not expect many breaking changes. When there is one, however, it is documented clearly here.
+
+Pre-v1.0.0 Breaking Changes
+-------------------------
+
+- May 11, 2017: `(*HTML).Node` is now a function instead of a struct field. ([PR #108](https://github.com/gopherjs/vecty/pull/108))

--- a/domutil.go
+++ b/domutil.go
@@ -1,12 +1,10 @@
 package vecty
 
-import "github.com/gopherjs/gopherjs/js"
-
-func removeNode(node *js.Object) {
+func removeNode(node jsObject) {
 	node.Get("parentNode").Call("removeChild", node)
 }
 
-func replaceNode(newNode, oldNode *js.Object) {
+func replaceNode(newNode, oldNode jsObject) {
 	if newNode == oldNode {
 		return
 	}

--- a/examples/todomvc/components/itemview.go
+++ b/examples/todomvc/components/itemview.go
@@ -46,7 +46,7 @@ func (p *ItemView) onStartEdit(event *vecty.Event) {
 	p.editing = true
 	p.editTitle = p.Item.Title
 	vecty.Rerender(p)
-	p.input.Node.Call("focus")
+	p.input.Node().Call("focus")
 }
 
 func (p *ItemView) onEditInput(event *vecty.Event) {


### PR DESCRIPTION
**Breaking:** `(*HTML).Node` is now a function instead of a struct field.

This change enables us to mock JS calls and ensure that Vecty performs the right
operations internally when something occurs. Actual tests will be added in
a follow-up PR, and will be compatible with `go test` (instead of `gopherjs test`).

Additionally, a `docs/CHANGELOG.md` file is added to communicate breaking changes clearly to users.

Helps https://github.com/gopherjs/vecty/issues/29 and https://github.com/gopherjs/vecty/pull/107#issuecomment-300897887