### PR TITLE
proper testing of Vecty

### DIFF
--- a/dom_test.go
+++ b/dom_test.go
@@ -15,7 +15,7 @@ var _ = func() bool {
 // TODO(slimsag): TestUnmounter; Unmounter.Unmount
 // TODO(slimsag): TestComponentOrHTML
 // TODO(slimsag): TestRestorer; Restorer.Restore
-// TODO(slimsag): TestHTML; HTML.Restore
+// TODO(slimsag): TestHTML; HTML.Restore; HTML.Node
 
 func TestTag(t *testing.T) {
 	markupCalled := false

--- a/dom_test.go
+++ b/dom_test.go
@@ -78,7 +78,7 @@ func TestRerender_nil(t *testing.T) {
 //
 // TODO(slimsag): Document in Rerender how this behaves (it should be no-op?).
 func TestRerender_no_prevRender(t *testing.T) {
-	t.Skip("BUG")
+	t.Skip("BUG") // TODO(slimsag)
 	Rerender(&componentFunc{
 		render: func() *HTML {
 			panic("expected no Render call") // TODO(slimsag): bug!
@@ -381,7 +381,7 @@ func TestRenderBody_ExpectsBody(t *testing.T) {
 // TestRenderBody_Restore_Skip tests that RenderBody panics when the
 // component's Restore method returns skip == true.
 func TestRenderBody_Restore_Skip(t *testing.T) {
-	t.Skip("BUG")
+	t.Skip("BUG") // TODO(slimsag)
 	body := &mockObject{}
 	bodySet := false
 	document := &mockObject{

--- a/dom_test.go
+++ b/dom_test.go
@@ -356,6 +356,11 @@ func TestRenderBody_ExpectsBody(t *testing.T) {
 			render:    Tag("div"),
 			wantPanic: "vecty: RenderBody expected Component.Render to return a body tag, found \"div\"",
 		},
+		{
+			name:      "nil",
+			render:    nil,
+			wantPanic: "vecty: RenderBody expected Component.Render to return a body tag, found \"noscript\"",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/dom_test.go
+++ b/dom_test.go
@@ -202,7 +202,28 @@ func TestRenderBody_Standard_loading(t *testing.T) {
 	}
 }
 
-// TODO(slimsag): TestSetTitle
+func TestSetTitle(t *testing.T) {
+	titleSet := ""
+	document := &mockObject{
+		set: func(key string, value interface{}) {
+			if key != "title" {
+				panic(fmt.Sprintf(`expected document.set "title", not %q`, key))
+			}
+			titleSet = value.(string)
+		},
+	}
+	global = &mockObject{
+		get: map[string]jsObject{
+			"document": document,
+		},
+	}
+	want := "foobar"
+	SetTitle(want)
+	if titleSet != want {
+		t.Fatalf("titleSet is %q, want %q", titleSet, want)
+	}
+}
+
 // TODO(slimsag): TestAddStylesheet
 
 type componentFunc struct {

--- a/dom_test.go
+++ b/dom_test.go
@@ -16,7 +16,23 @@ var _ = func() bool {
 // TODO(slimsag): TestComponentOrHTML
 // TODO(slimsag): TestRestorer; Restorer.Restore
 // TODO(slimsag): TestHTML; HTML.Restore
-// TODO(slimsag): TestTag
+
+func TestTag(t *testing.T) {
+	markupCalled := false
+	want := "foobar"
+	h := Tag(want, markupFunc(func(h *HTML) {
+		markupCalled = true
+	}))
+	if !markupCalled {
+		t.Fatal("expected markup to be applied")
+	}
+	if h.tag != want {
+		t.Fatalf("got tag %q want tag %q", h.text, want)
+	}
+	if h.text != "" {
+		t.Fatal("expected no text")
+	}
+}
 
 func TestText(t *testing.T) {
 	markupCalled := false

--- a/dom_test.go
+++ b/dom_test.go
@@ -1,6 +1,77 @@
 package vecty
 
+import (
+	"fmt"
+	"testing"
+)
+
 var _ = func() bool {
 	isTest = true
 	return true
 }()
+
+// TODO(slimsag): TestCore; Core.Context
+// TODO(slimsag): TestComponent; Component.Render; Component.Context
+// TODO(slimsag): TestUnmounter; Unmounter.Unmount
+// TODO(slimsag): TestComponentOrHTML
+// TODO(slimsag): TestRestorer; Restorer.Restore
+// TODO(slimsag): TestHTML; HTML.Restore
+// TODO(slimsag): TestTag
+// TODO(slimsag): TestText
+// TODO(slimsag): TestRerender
+
+// TestRenderBody_ExpectsBody tests that RenderBody always expects a "body" tag
+// and panics otherwise.
+func TestRenderBody_ExpectsBody(t *testing.T) {
+	cases := []struct {
+		name      string
+		render    *HTML
+		wantPanic string
+	}{
+		{
+			name:      "text",
+			render:    Text("Hello world!"),
+			wantPanic: "vecty: RenderBody expected Component.Render to return a body tag, found \"\"", // TODO(slimsag): bug
+		},
+		{
+			name:      "div",
+			render:    Tag("div"),
+			wantPanic: "vecty: RenderBody expected Component.Render to return a body tag, found \"div\"",
+		},
+		{
+			name:      "body",
+			render:    Tag("body"),
+			wantPanic: "runtime error: invalid memory address or nil pointer dereference", // TODO(slimsag): relies on js
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var gotPanic string
+			func() {
+				defer func() {
+					r := recover()
+					if r != nil {
+						gotPanic = fmt.Sprint(r)
+					}
+				}()
+				RenderBody(&componentFunc{render: func() *HTML {
+					return c.render
+				}})
+			}()
+			if c.wantPanic != gotPanic {
+				t.Fatalf("want panic %q got panic %q", c.wantPanic, gotPanic)
+			}
+		})
+	}
+}
+
+// TODO(slimsag): TestRenderBody_Standard
+// TODO(slimsag): TestSetTitle
+// TODO(slimsag): TestAddStylesheet
+
+type componentFunc struct {
+	Core
+	render func() *HTML
+}
+
+func (c *componentFunc) Render() *HTML { return c.render() }

--- a/dom_test.go
+++ b/dom_test.go
@@ -1,0 +1,6 @@
+package vecty
+
+var _ = func() bool {
+	isTest = true
+	return true
+}()

--- a/dom_test.go
+++ b/dom_test.go
@@ -17,7 +17,24 @@ var _ = func() bool {
 // TODO(slimsag): TestRestorer; Restorer.Restore
 // TODO(slimsag): TestHTML; HTML.Restore
 // TODO(slimsag): TestTag
-// TODO(slimsag): TestText
+
+func TestText(t *testing.T) {
+	markupCalled := false
+	want := "Hello world!"
+	h := Text(want, markupFunc(func(h *HTML) {
+		markupCalled = true
+	}))
+	if !markupCalled {
+		t.Fatal("expected markup to be applied")
+	}
+	if h.text != want {
+		t.Fatalf("got text %q want text %q", h.text, want)
+	}
+	if h.tag != "" {
+		t.Fatal("expected no tag")
+	}
+}
+
 // TODO(slimsag): TestRerender
 
 // TestRenderBody_ExpectsBody tests that RenderBody always expects a "body" tag

--- a/dom_test.go
+++ b/dom_test.go
@@ -224,7 +224,72 @@ func TestSetTitle(t *testing.T) {
 	}
 }
 
-// TODO(slimsag): TestAddStylesheet
+func TestAddStylesheet(t *testing.T) {
+	linkSet := map[string]interface{}{}
+	link := &mockObject{
+		set: func(key string, value interface{}) {
+			linkSet[key] = value
+		},
+	}
+	appendedToHead := false
+	head := &mockObject{
+		call: func(name string, args ...interface{}) jsObject {
+			switch name {
+			case "appendChild":
+				if len(args) != 1 {
+					panic("len(args) != 1")
+				}
+				if args[0] != link {
+					panic(`args[0] != link`)
+				}
+				appendedToHead = true
+				return nil
+			default:
+				panic(fmt.Sprintf("unexpected call to %q", name))
+			}
+		},
+	}
+	document := &mockObject{
+		call: func(name string, args ...interface{}) jsObject {
+			switch name {
+			case "createElement":
+				if len(args) != 1 {
+					panic("len(args) != 1")
+				}
+				if args[0].(string) != "link" {
+					panic(`args[0].(string) != "link"`)
+				}
+				return link
+			default:
+				panic(fmt.Sprintf("unexpected call to %q", name))
+			}
+		},
+		set: func(key string, value interface{}) {
+			if key != "title" {
+				panic(fmt.Sprintf(`expected document.set "title", not %q`, key))
+			}
+		},
+		get: map[string]jsObject{
+			"head": head,
+		},
+	}
+	global = &mockObject{
+		get: map[string]jsObject{
+			"document": document,
+		},
+	}
+	url := "https://google.com/foobar.css"
+	AddStylesheet(url)
+	if !appendedToHead {
+		t.Fatal("expected link to be appended to document.head")
+	}
+	if linkSet["rel"] != "stylesheet" {
+		t.Fatal(`linkSet["rel"] != "stylesheet"`)
+	}
+	if linkSet["href"] != url {
+		t.Fatal(`linkSet["href"] != url`)
+	}
+}
 
 type componentFunc struct {
 	Core

--- a/dom_test.go
+++ b/dom_test.go
@@ -81,7 +81,6 @@ func TestCore(t *testing.T) {
 }
 
 // TODO(slimsag): TestUnmounter; Unmounter.Unmount
-// TODO(slimsag): TestHTML_Restore for restoreText and restoreHTML paths
 
 func TestHTML_Node(t *testing.T) {
 	x := &js.Object{}
@@ -89,6 +88,49 @@ func TestHTML_Node(t *testing.T) {
 	if h.Node() != x {
 		t.Fatal("h.Node() != x")
 	}
+}
+
+// TestHTML_Restore_std tests that (*HTML).Restore against an old HTML instance
+// works as expected (i.e. that it updates nodes correctly).
+func TestHTML_Restore_std(t *testing.T) {
+	t.Run("text_identical", func(t *testing.T) {
+		h := Text("foobar")
+		hNode := &mockObject{}
+		h.node = hNode
+		prev := Text("foobar")
+		prevNode := &mockObject{}
+		prev.node = prevNode
+		h.Restore(prev)
+		if h.node != prevNode {
+			t.Fatal("h.node != prevNode")
+		}
+	})
+	t.Run("text_diff", func(t *testing.T) {
+		want := "bar"
+		h := Text(want)
+		hNode := &mockObject{}
+		h.node = hNode
+		prev := Text("foo")
+		setNodeValue := ""
+		prevNode := &mockObject{
+			set: func(key string, value interface{}) {
+				if key != "nodeValue" {
+					panic(`key != "nodeValue"`)
+				}
+				setNodeValue = value.(string)
+			},
+		}
+		prev.node = prevNode
+		h.Restore(prev)
+		if h.node != prevNode {
+			t.Fatal("h.node != prevNode")
+		}
+		if setNodeValue != want {
+			t.Fatalf("got %q want %q", setNodeValue, want)
+		}
+	})
+
+	// TODO(slimsag): test the restoreHTML code path
 }
 
 // TestHTML_Restore_nil tests that (*HTML).Restore(nil) works as expected (i.e.

--- a/gopherjs_only.go
+++ b/gopherjs_only.go
@@ -2,6 +2,11 @@
 
 package vecty
 
+var isTest bool
+
 func init() {
+	if isTest {
+		return
+	}
 	panic("vecty: only GopherJS compiler is supported")
 }


### PR DESCRIPTION
This change adds 38 tests for the core functionality of Vecty.

Notably missing is tests for the code path of `(*HTML).Restore(prev)` calling `restoreHTML`, which I intend to add very soon.

Coverage report:

```
coverage: 64.3% of statements
```

Note: This change will make the PR https://github.com/gopherjs/vecty/pull/107 wholly unmergable in its current state since it is such an invasive change. But it's more important long term that we get proper testing in place, otherwise I cannot merge small PRs at all. (I need to have confidence that they do not cause regressions). For 107 in specific, I will be manually splitting it into smaller PRs against master, as time permits.

Helps https://github.com/gopherjs/vecty/issues/29