### PR TITLE
Add Namespace for creating namespaced elements (e.g. for inline SVG)

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -79,11 +79,11 @@ type Restorer interface {
 type HTML struct {
 	node jsObject
 
-	tag, text, innerHTML   string
-	styles, dataset        map[string]string
-	properties, attributes map[string]interface{}
-	eventListeners         []*EventListener
-	children               []ComponentOrHTML
+	namespace, tag, text, innerHTML string
+	styles, dataset                 map[string]string
+	properties, attributes          map[string]interface{}
+	eventListeners                  []*EventListener
+	children                        []ComponentOrHTML
 }
 
 func (h *HTML) Node() *js.Object { return h.node.(wrappedObject).j }
@@ -226,9 +226,12 @@ func (h *HTML) Restore(old ComponentOrHTML) {
 	if h.text != "" && h.innerHTML != "" {
 		panic("vecty: only HTML may have UnsafeHTML attribute")
 	}
-	if h.tag != "" {
+	switch {
+	case h.tag != "" && h.namespace == "":
 		h.node = global.Get("document").Call("createElement", h.tag)
-	} else {
+	case h.tag != "" && h.namespace != "":
+		h.node = global.Get("document").Call("createElementNS", h.namespace, h.tag)
+	default:
 		h.node = global.Get("document").Call("createTextNode", h.text)
 	}
 	if h.innerHTML != "" {

--- a/dom_test.go
+++ b/dom_test.go
@@ -183,6 +183,39 @@ func TestHTML_Restore_nil(t *testing.T) {
 			t.Fatalf("createdElement %q want %q", createdElement, want)
 		}
 	})
+	t.Run("create_element_ns", func(t *testing.T) {
+		strong := &mockObject{}
+		createdNamespace := ""
+		createdElement := ""
+		document := &mockObject{
+			call: func(name string, args ...interface{}) jsObject {
+				if name != "createElementNS" {
+					panic(fmt.Sprintf("expected call to createElementNS, not %q", name))
+				}
+				if len(args) != 2 {
+					panic("len(args) != 2")
+				}
+				createdNamespace = args[0].(string)
+				createdElement = args[1].(string)
+				return strong
+			},
+		}
+		global = &mockObject{
+			get: map[string]jsObject{
+				"document": document,
+			},
+		}
+		wantTag := "strong"
+		wantNamespace := "foobar"
+		h := Tag(wantTag, Namespace(wantNamespace))
+		h.Restore(nil)
+		if createdElement != wantTag {
+			t.Fatalf("createdElement %q want tag %q", createdElement, wantTag)
+		}
+		if createdNamespace != wantNamespace {
+			t.Fatalf("createdNamespace %q want namespace %q", createdElement, wantNamespace)
+		}
+	})
 	t.Run("create_text_node", func(t *testing.T) {
 		textNode := &mockObject{}
 		createdTextNode := ""

--- a/markup.go
+++ b/markup.go
@@ -114,8 +114,7 @@ func Property(key string, value interface{}) Markup {
 	})
 }
 
-// Attribute returns Markup which applies the given HTML attribute to an HTML
-// element.
+// Attribute returns Markup which applies the given attribute to an element.
 //
 // In most situations, you should use Property function, or the prop subpackage
 // (which is type-safe) instead. There are only a few attributes (aria-*, role,
@@ -190,5 +189,15 @@ func If(cond bool, markup ...MarkupOrComponentOrHTML) MarkupOrComponentOrHTML {
 func UnsafeHTML(html string) Markup {
 	return markupFunc(func(h *HTML) {
 		h.innerHTML = html
+	})
+}
+
+// Namespace is Markup which sets the namespace URI to associate with the
+// created element. This is primarily used when working with, e.g., SVG.
+//
+// See https://developer.mozilla.org/en-US/docs/Web/API/Document/createElementNS#Valid Namespace URIs
+func Namespace(uri string) Markup {
+	return markupFunc(func(h *HTML) {
+		h.namespace = uri
 	})
 }

--- a/markup_test.go
+++ b/markup_test.go
@@ -1,0 +1,13 @@
+package vecty
+
+import "testing"
+
+// TODO(slimsag): tests for other Markup
+
+func TestNamespace(t *testing.T) {
+	want := "b"
+	h := Tag("a", Namespace(want))
+	if h.namespace != want {
+		t.Fatalf("got namespace %q want %q", h.namespace, want)
+	}
+}


### PR DESCRIPTION
This allows the creation of elements like inline SVG.

Helps #54

Author amended to @pdf instead of me (@slimsag), to provide credit for his
original change at https://github.com/gopherjs/vecty/pull/107