### PR TITLE
Rerender improvements

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -9,7 +9,8 @@ import (
 // Core implements the Context method of the Component interface, and is the
 // core/central struct which all Component implementations should embed.
 type Core struct {
-	prevRender *HTML
+	prevComponent Component
+	prevRender    *HTML
 }
 
 // Context implements the Component interface.
@@ -309,8 +310,7 @@ func Rerender(c Component) {
 		panic("vecty: Rerender invoked on Component that has never been rendered")
 	}
 	nextRender := doRender(c)
-	var prevComponent Component // TODO
-	if doRestore(prevComponent, c, prevRender, nextRender) {
+	if doRestore(c.Context().prevComponent, c, prevRender, nextRender) {
 		return
 	}
 	replaceNode(nextRender.node, prevRender.node)
@@ -323,6 +323,7 @@ func doRender(c ComponentOrHTML) *HTML {
 	comp := c.(Component)
 	r := renderHandleNil(comp)
 	comp.Context().prevRender = r
+	comp.Context().prevComponent = comp
 	return r
 }
 

--- a/dom.go
+++ b/dom.go
@@ -301,6 +301,9 @@ func Text(text string, m ...MarkupOrComponentOrHTML) *HTML {
 //
 // If the component has not been rendered before, Rerender panics.
 func Rerender(c Component) {
+	if c == nil {
+		panic("vecty: Rerender illegally called with a nil Component argument")
+	}
 	prevRender := c.Context().prevRender
 	if prevRender == nil {
 		panic("vecty: Rerender invoked on Component that has never been rendered")

--- a/dom.go
+++ b/dom.go
@@ -298,16 +298,19 @@ func Text(text string, m ...MarkupOrComponentOrHTML) *HTML {
 
 // Rerender causes the body of the given component (i.e. the HTML returned by
 // the Component's Render method) to be re-rendered and subsequently restored.
+//
+// If the component has not been rendered before, Rerender panics.
 func Rerender(c Component) {
 	prevRender := c.Context().prevRender
+	if prevRender == nil {
+		panic("vecty: Rerender invoked on Component that has never been rendered")
+	}
 	nextRender := doRender(c)
 	var prevComponent Component // TODO
 	if doRestore(prevComponent, c, prevRender, nextRender) {
 		return
 	}
-	if prevRender != nil {
-		replaceNode(nextRender.node, prevRender.node)
-	}
+	replaceNode(nextRender.node, prevRender.node)
 }
 
 func doRender(c ComponentOrHTML) *HTML {

--- a/dom.go
+++ b/dom.go
@@ -297,7 +297,7 @@ func Text(text string, m ...MarkupOrComponentOrHTML) *HTML {
 }
 
 // Rerender causes the body of the given component (i.e. the HTML returned by
-// the Component's Render method) to be re-rendered and subsequently restored.
+// the Component's Render method) to be re-rendered.
 //
 // If the component has not been rendered before, Rerender panics.
 func Rerender(c Component) {

--- a/dom_test.go
+++ b/dom_test.go
@@ -812,10 +812,9 @@ func TestRerender_identical(t *testing.T) {
 		return newRender
 	}
 	comp.restore = func(prev Component) (skip bool) {
-		// TODO(slimsag): https://github.com/gopherjs/vecty/issues/106
-		//if prev != comp {
-		//	panic("prev != comp")
-		//}
+		if prev != comp {
+			panic("prev != comp")
+		}
 		restoreCalled++
 		return
 	}
@@ -962,10 +961,9 @@ func TestRerender_change(t *testing.T) {
 				return tst.newRender
 			}
 			comp.restore = func(prev Component) (skip bool) {
-				// TODO(slimsag): https://github.com/gopherjs/vecty/issues/106
-				//if prev != comp {
-				//	panic("prev != comp")
-				//}
+				if prev != comp {
+					panic("prev != comp")
+				}
 				restoreCalled++
 				return
 			}
@@ -978,6 +976,9 @@ func TestRerender_change(t *testing.T) {
 			}
 			if comp.Context().prevRender != tst.newRender {
 				t.Fatal("comp.Context().prevRender != tst.newRender")
+			}
+			if comp.Context().prevComponent != comp {
+				t.Fatal("comp.Context().prevComponent != comp")
 			}
 			if bodyAppendChild != newNode {
 				t.Fatal("bodyAppendChild != newNode")

--- a/dom_test.go
+++ b/dom_test.go
@@ -723,18 +723,21 @@ func TestRerender_nil(t *testing.T) {
 
 // TestRerender_no_prevRender tests the behavior of Rerender when there is no
 // previous render.
-//
-// TODO(slimsag): Document in Rerender how this behaves (it should be no-op?).
 func TestRerender_no_prevRender(t *testing.T) {
-	t.Skip("BUG") // TODO(slimsag)
-	Rerender(&componentFunc{
-		render: func() *HTML {
-			panic("expected no Render call") // TODO(slimsag): bug!
-		},
-		restore: func(prev Component) (skip bool) {
-			panic("expected no Restore call") // TODO(slimsag): bug!
-		},
+	got := recoverStr(func() {
+		Rerender(&componentFunc{
+			render: func() *HTML {
+				panic("expected no Render call")
+			},
+			restore: func(prev Component) (skip bool) {
+				panic("expected no Restore call")
+			},
+		})
 	})
+	want := "vecty: Rerender invoked on Component that has never been rendered"
+	if got != want {
+		t.Fatalf("got panic %q expected %q", got, want)
+	}
 }
 
 // TestRerender_identical tests the behavior of Rerender when there is a

--- a/dom_test.go
+++ b/dom_test.go
@@ -699,9 +699,6 @@ func TestText(t *testing.T) {
 	}
 }
 
-// TODO(slimsag): Rerender docs say "re-rendered and subsequently restored"
-// which is not right (Restore happens before Render).
-
 // TestRerender_nil tests that Rerender panics when the component argument is
 // nil.
 func TestRerender_nil(t *testing.T) {

--- a/dom_test.go
+++ b/dom_test.go
@@ -712,7 +712,7 @@ func TestRerender_nil(t *testing.T) {
 		}()
 		Rerender(nil)
 	}()
-	expected := "runtime error: invalid memory address or nil pointer dereference" // TODO(slimsag): error message bug
+	expected := "vecty: Rerender illegally called with a nil Component argument"
 	if gotPanic != expected {
 		t.Fatalf("got panic %q expected %q", gotPanic, expected)
 	}

--- a/examples/todomvc/components/itemview.go
+++ b/examples/todomvc/components/itemview.go
@@ -24,12 +24,11 @@ type ItemView struct {
 }
 
 // Restore implements the vecty.Restorer interface.
-func (p *ItemView) Restore(prev vecty.Component) bool {
+func (p *ItemView) Restore(prev vecty.Component) {
 	if old, ok := prev.(*ItemView); ok {
 		p.editing = old.editing
 		p.editTitle = old.editTitle
 	}
-	return false
 }
 
 func (p *ItemView) onDestroy(event *vecty.Event) {

--- a/examples/todomvc/components/pageview.go
+++ b/examples/todomvc/components/pageview.go
@@ -23,11 +23,10 @@ type PageView struct {
 }
 
 // Restore implements the vecty.Restorer interface.
-func (p *PageView) Restore(prev vecty.Component) bool {
+func (p *PageView) Restore(prev vecty.Component) {
 	if old, ok := prev.(*PageView); ok {
 		p.newItemTitle = old.newItemTitle
 	}
-	return false
 }
 
 func (p *PageView) onNewItemTitleInput(event *vecty.Event) {


### PR DESCRIPTION
- Invoking `Rerender` on a component with no previous render now panics with a more helpful error message.
- General `Rerender` documentation improvements.
- Improve panic message when a user invokes `Rerender(nil)` by accident.
- Fix bug with `Rerender` not invoking the component `Restore` method with the previous component.

Fixes #106 
Helps #92 