### PR TITLE
Fix rendering of child nodes for incompatible elements

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -259,7 +259,8 @@ func (h *HTML) reconcile(prev *HTML) {
 
 	// TODO better list element reuse
 	for i, nextChild := range h.children {
-		if i >= len(prev.children) {
+		// TODO(pdf): Add tests for h.new usage
+		if i >= len(prev.children) || h.new {
 			nextChildRender, skip := render(nextChild, nil)
 			if skip {
 				continue


### PR DESCRIPTION
Fixes #121 

I had this change in my previous code, but missed it when writing #117.  This change is required because new (incompatible) nodes always need their children appended.

I will try to get tests sorted out for child mutations over the weekend.

