### PR TITLE
add new logo design; CONTRIBUTORS file

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,12 @@
+# Names should be added to this file like so:
+#
+#  Jane Doe <jane@gmail.com>
+#  Jane Doe <preferred_link>
+#  Jane Doe <jane@gmail.com> <preferred_link>
+#
+# <preferred_link> may be the person's website, GitHub profile, or GitHub
+# project related to their contribution to Vecty.
+
+# Please keep the list sorted.
+
+Stephen Gutekanst <stephen.gutekanst@gmail.com> <github.com/slimsag>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,4 +9,5 @@
 
 # Please keep the list sorted.
 
+Igor Afanasyev <github.com/iafan/vecty-logo>
 Stephen Gutekanst <stephen.gutekanst@gmail.com> <github.com/slimsag>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-	<img src="https://drive.google.com/uc?id=0B2Crq763J1N4SnpwalZTeVE5RmM" />
+	<img src="https://github.com/vecty/vecty-logo/raw/master/horizontal_color.png" />
 </p>
 
 Vecty is a [React](https://facebook.github.io/react/)-like library for [GopherJS](https://github.com/gopherjs/gopherjs) so that you can do frontend development in Go instead of writing JavaScript/HTML/CSS.


### PR DESCRIPTION
@iafan has kindly made a new logo design for the project:

![](https://github.com/vecty/vecty-logo/raw/master/horizontal_color.png)

compare with the old design:

![](https://drive.google.com/uc?id=0B2Crq763J1N4SnpwalZTeVE5RmM)

I've forked the repository https://github.com/iafan/vecty-logo to the 'vecty' organization just to avoid it potentially disappearing for any reason.

Also added is a new `CONTRIBUTORS` file in which people may add themselves (if they desire) to receive proper credit for their work :)