### PR TITLE
Lifecycle design changes (2) (persistent component instances)

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,5 +6,6 @@ Although v1.0.0 [is not yet out](https://github.com/gopherjs/vecty/milestone/1),
 Pre-v1.0.0 Breaking Changes
 ---------------------------
 
+- Aug 6, 2017: The `Restorer` interface has been removed, component instances are now persistent. Properties should be denoted via ``` `vecty:"prop"` ``` struct field tags. ([PR #131](https://github.com/gopherjs/vecty/pull/131))
 - Jun 17, 2017: `(*HTML).Restore` is no longer exported, this method was not generally used externally. ([PR #117](https://github.com/gopherjs/vecty/pull/117))
 - May 11, 2017: `(*HTML).Node` is now a function instead of a struct field. ([PR #108](https://github.com/gopherjs/vecty/pull/108))

--- a/dom.go
+++ b/dom.go
@@ -363,10 +363,11 @@ func doCopy(c Component) Component {
 	return cpy.Interface().(Component)
 }
 
-// render the ComponentOrHTML. In the case of *HTML, its reconcile method is
-// invoked with the specified prevRender and c.(*HTML) is returned.
+// render renders the ComponentOrHTML. In the case of *HTML, its reconcile
+// method is invoked with the specified prevRender and c.(*HTML) is returned.
 //
-// In the case of a Component, renderComponent(c.(Component)) is returned.
+// In the case of a Component, renderComponent(c.(Component), prevRender) is
+// returned.
 func render(next, prev ComponentOrHTML) (h *HTML, skip bool) {
 	switch v := next.(type) {
 	case *HTML:

--- a/dom.go
+++ b/dom.go
@@ -257,10 +257,16 @@ func (h *HTML) reconcile(prev *HTML) {
 			continue
 		}
 
-		prevChildRender := assertHTML(prev.children[i])
-		nextChildRender, skip := render(nextChild, prevChildRender)
+		prevChild := prev.children[i]
+		prevChildRender := assertHTML(prevChild)
+		nextChildRender, skip := render(nextChild, prevChild)
 		if nextChildRender == prevChildRender {
 			panic("vecty: next child render must not equal previous child render (did the child Render illegally return a stored render variable?)")
+		}
+		if prevComponent, ok := prevChild.(Component); ok {
+			if nextComponent, ok := nextChild.(Component); ok && matchComponent(prevComponent, nextComponent) {
+				h.children[i] = prevChild
+			}
 		}
 		if skip {
 			continue
@@ -336,6 +342,11 @@ func assertHTML(e ComponentOrHTML) *HTML {
 	}
 }
 
+// matchComponent returns whether first and second components are of the same type
+func matchComponent(first, second Component) bool {
+	return reflect.TypeOf(first) == reflect.TypeOf(second)
+}
+
 // doCopy makes a copy of the given component.
 func doCopy(c Component) Component {
 	if c == nil {
@@ -363,18 +374,49 @@ func doCopy(c Component) Component {
 	return cpy.Interface().(Component)
 }
 
-// render renders the ComponentOrHTML. In the case of *HTML, its reconcile
-// method is invoked with the specified prevRender and c.(*HTML) is returned.
+// copyProps copies all struct fields from src to dst that are tagged with
+// `vecty:"prop"`.
 //
-// In the case of a Component, renderComponent(c.(Component), prevRender) is
-// returned.
+// If src and dst are different types, copyProps is no-op.
+func copyProps(src, dst Component) {
+	s := reflect.ValueOf(src)
+	d := reflect.ValueOf(dst)
+	if s.Type() != d.Type() {
+		return
+	}
+	for i := 0; i < s.Elem().NumField(); i++ {
+		sf := s.Elem().Field(i)
+		if s.Elem().Type().Field(i).Tag.Get("vecty") == "prop" {
+			df := d.Elem().Field(i)
+			if sf.Type() != df.Type() {
+				panic("vecty: internal error (should never be possible, struct types are identical)")
+			}
+			df.Set(sf)
+		}
+	}
+}
+
+// render handles rendering the next child into HTML. If skip is returned,
+// the component's SkipRender method has signaled to skip rendering.
+//
+// In specific, render handles six cases:
+//
+// 1. nextChild == *HTML && prevChild == *HTML
+// 2. nextChild == *HTML && prevChild == Component
+// 3. nextChild == *HTML && prevChild == nil
+// 4. nextChild == Component && prevChild == Component
+// 5. nextChild == Component && prevChild == *HTML
+// 6. nextChild == Component && prevChild == nil
+//
 func render(next, prev ComponentOrHTML) (h *HTML, skip bool) {
 	switch v := next.(type) {
 	case *HTML:
+		// Cases 1, 2 and 3 above. Reconcile against the prevRender.
 		v.reconcile(assertHTML(prev))
 		return v, false
 	case Component:
-		return renderComponent(v, assertHTML(prev))
+		// Cases 4, 5, and 6 above.
+		return renderComponent(v, prev)
 	default:
 		panic(fmt.Sprintf("vecty: encountered invalid ComponentOrHTML %T", next))
 	}
@@ -383,34 +425,45 @@ func render(next, prev ComponentOrHTML) (h *HTML, skip bool) {
 // renderComponent handles rendering the given Component into *HTML. If skip ==
 // true is returned, the Component's SkipRender method has signaled the
 // component does not need to be rendered and h == nil is returned.
-func renderComponent(comp Component, prevRender *HTML) (h *HTML, skip bool) {
+func renderComponent(next Component, prev ComponentOrHTML) (h *HTML, skip bool) {
+	// If we had a component last render, and it's of compatible type, operate
+	// on the previous instance.
+	if prevComponent, ok := prev.(Component); ok && matchComponent(next, prevComponent) {
+		// Copy `vecty:"prop"` fields from the newly rendered component (next)
+		// into the persistent component instance (prev) so that it is aware of
+		// what properties the parent has specified during SkipRender/Render
+		// below.
+		copyProps(next, prevComponent)
+		next = prevComponent
+	}
+
 	// Before rendering, consult the Component's SkipRender method to see if we
 	// should skip rendering or not.
-	if rs, ok := comp.(RenderSkipper); ok {
-		prev := comp.Context().prevComponent
-		if prev != nil {
-			if comp == prev {
+	if rs, ok := next.(RenderSkipper); ok {
+		prevComponent := next.Context().prevComponent
+		if prevComponent != nil {
+			if next == prevComponent {
 				panic("vecty: internal error (SkipRender called with identical prev component)")
 			}
-			if rs.SkipRender(prev) {
+			if rs.SkipRender(prevComponent) {
 				return nil, true
 			}
 		}
 	}
 
 	// Render the component into HTML, handling nil renders.
-	nextRender := comp.Render()
+	nextRender := next.Render()
 	if nextRender == nil {
 		// nil renders are translated into noscript tags.
 		nextRender = Tag("noscript")
 	}
 
 	// Reconcile the actual rendered HTML.
-	nextRender.reconcile(prevRender)
+	nextRender.reconcile(assertHTML(prev))
 
 	// Update the context to consider this render.
-	comp.Context().prevRender = nextRender
-	comp.Context().prevComponent = doCopy(comp)
+	next.Context().prevRender = nextRender
+	next.Context().prevComponent = doCopy(next)
 	return nextRender, false
 }
 

--- a/dom.go
+++ b/dom.go
@@ -69,18 +69,6 @@ type Unmounter interface {
 // value is expected to panic.
 type ComponentOrHTML interface{}
 
-// Restorer is an optional interface that Component's can implement in order to
-// restore state during component reconciliation.
-type Restorer interface {
-	// Restore is called when the component should restore itself against a
-	// previous instance of a component.
-	//
-	// The previous component may be nil or of a different type than this
-	// Restorer itself, thus a type assertion should be used no action taken
-	// if the type does not match.
-	Restore(prev Component)
-}
-
 // RenderSkipper is an optional interface that Component's can implement in
 // order to short-circuit the reconciliation of a Component's rendered body.
 //
@@ -375,7 +363,7 @@ func doCopy(c Component) Component {
 	return cpy.Interface().(Component)
 }
 
-// render the ComponentOrHTML. In the case of *HTML, its Restore method is
+// render the ComponentOrHTML. In the case of *HTML, its reconcile method is
 // invoked with the specified prevRender and c.(*HTML) is returned.
 //
 // In the case of a Component, renderComponent(c.(Component)) is returned.
@@ -395,14 +383,6 @@ func render(next, prev ComponentOrHTML) (h *HTML, skip bool) {
 // true is returned, the Component's SkipRender method has signaled the
 // component does not need to be rendered and h == nil is returned.
 func renderComponent(comp Component, prevRender *HTML) (h *HTML, skip bool) {
-	// Now that we know we are rendering the component, restore friendly
-	// relations between the component and the previous component.
-	if comp != comp.Context().prevComponent {
-		if r, ok := comp.(Restorer); ok {
-			r.Restore(comp.Context().prevComponent)
-		}
-	}
-
 	// Before rendering, consult the Component's SkipRender method to see if we
 	// should skip rendering or not.
 	if rs, ok := comp.(RenderSkipper); ok {
@@ -424,7 +404,7 @@ func renderComponent(comp Component, prevRender *HTML) (h *HTML, skip bool) {
 		nextRender = Tag("noscript")
 	}
 
-	// Restore the actual rendered HTML.
+	// Reconcile the actual rendered HTML.
 	nextRender.reconcile(prevRender)
 
 	// Update the context to consider this render.

--- a/dom.go
+++ b/dom.go
@@ -10,8 +10,8 @@ import (
 // Core implements the Context method of the Component interface, and is the
 // core/central struct which all Component implementations should embed.
 type Core struct {
-	prevComponent, prevRenderComponent Component
-	prevRender                         *HTML
+	prevComponent Component
+	prevRender    *HTML
 }
 
 // Context implements the Component interface.
@@ -386,7 +386,7 @@ func renderComponent(comp Component, prevRender *HTML) (h *HTML, skip bool) {
 	// Before rendering, consult the Component's SkipRender method to see if we
 	// should skip rendering or not.
 	if rs, ok := comp.(RenderSkipper); ok {
-		prev := comp.Context().prevRenderComponent
+		prev := comp.Context().prevComponent
 		if prev != nil {
 			if comp == prev {
 				panic("vecty: internal error (SkipRender called with identical prev component)")
@@ -409,8 +409,7 @@ func renderComponent(comp Component, prevRender *HTML) (h *HTML, skip bool) {
 
 	// Update the context to consider this render.
 	comp.Context().prevRender = nextRender
-	comp.Context().prevComponent = comp
-	comp.Context().prevRenderComponent = doCopy(comp)
+	comp.Context().prevComponent = doCopy(comp)
 	return nextRender, false
 }
 

--- a/dom_test.go
+++ b/dom_test.go
@@ -946,11 +946,8 @@ func TestHTML_reconcile_nil(t *testing.T) {
 		if compRenderCalls != 1 {
 			t.Fatal("compRenderCalls != 1")
 		}
-		if comp.Context().prevComponent != comp {
-			t.Fatal("comp.Context().prevComponent != comp")
-		}
-		if comp.Context().prevRenderComponent.(*componentFunc).id != comp.id {
-			t.Fatal("comp.Context().prevRenderComponent.(*componentFunc).id != comp.id")
+		if comp.Context().prevComponent.(*componentFunc).id != comp.id {
+			t.Fatal("comp.Context().prevComponent.(*componentFunc).id != comp.id")
 		}
 		if comp.Context().prevRender != compRender {
 			t.Fatal("comp.Context().prevRender != compRender")
@@ -1023,11 +1020,8 @@ func TestHTML_reconcile_nil(t *testing.T) {
 		if compRenderCalls != 1 {
 			t.Fatal("compRenderCalls != 1")
 		}
-		if comp.Context().prevComponent != comp {
-			t.Fatal("comp.Context().prevComponent != comp")
-		}
-		if comp.Context().prevRenderComponent.(*componentFunc).id != comp.id {
-			t.Fatal("comp.Context().prevRenderComponent.(*componentFunc).id != comp.id")
+		if comp.Context().prevComponent.(*componentFunc).id != comp.id {
+			t.Fatal("comp.Context().prevComponent.(*componentFunc).id != comp.id")
 		}
 		if comp.Context().prevRender == nil {
 			t.Fatal("comp.Context().prevRender == nil")
@@ -1176,9 +1170,6 @@ func TestRerender_identical(t *testing.T) {
 	if comp.Context().prevComponent.(*componentFunc).id != "original" {
 		t.Fatal(`comp.Context().prevComponent.(*componentFunc).id != "original"`)
 	}
-	if comp.Context().prevRenderComponent.(*componentFunc).id != "original" {
-		t.Fatal(`comp.Context().prevRenderComponent.(*componentFunc).id != "original"`)
-	}
 
 	// Perform a re-render.
 	global = nil // Expecting no JS calls past here
@@ -1192,11 +1183,8 @@ func TestRerender_identical(t *testing.T) {
 		if comp.id != "modified" {
 			panic(`comp.id != "modified"`)
 		}
-		if comp.Context().prevComponent.(*componentFunc).id != "modified" {
-			panic(`comp.Context().prevComponent.(*componentFunc).id != "modified"`)
-		}
-		if comp.Context().prevRenderComponent.(*componentFunc).id != "original" {
-			panic(`comp.Context().prevRenderComponent.(*componentFunc).id != "original"`)
+		if comp.Context().prevComponent.(*componentFunc).id != "original" {
+			panic(`comp.Context().prevComponent.(*componentFunc).id != "original"`)
 		}
 		if prev.(*componentFunc).id != "original" {
 			panic(`prev.(*componentFunc).id != "original"`)
@@ -1216,9 +1204,6 @@ func TestRerender_identical(t *testing.T) {
 	}
 	if comp.Context().prevComponent.(*componentFunc).id != "modified" {
 		t.Fatal(`comp.Context().prevComponent.(*componentFunc).id != "modified"`)
-	}
-	if comp.Context().prevRenderComponent.(*componentFunc).id != "modified" {
-		t.Fatal(`comp.Context().prevRenderComponent.(*componentFunc).id != "modified"`)
 	}
 }
 
@@ -1310,8 +1295,8 @@ func TestRerender_change(t *testing.T) {
 			if comp.Context().prevRender != render {
 				t.Fatal("comp.Context().prevRender != render")
 			}
-			if comp.Context().prevRenderComponent.(*componentFunc).id != "original" {
-				t.Fatal(`comp.Context().prevRenderComponent.(*componentFunc).id != "original"`)
+			if comp.Context().prevComponent.(*componentFunc).id != "original" {
+				t.Fatal(`comp.Context().prevComponent.(*componentFunc).id != "original"`)
 			}
 
 			// Perform a re-render.
@@ -1351,11 +1336,8 @@ func TestRerender_change(t *testing.T) {
 				if comp.id != "modified" {
 					panic(`comp.id != "modified"`)
 				}
-				if comp.Context().prevComponent.(*componentFunc).id != "modified" {
-					panic(`comp.Context().prevComponent.(*componentFunc).id != "modified"`)
-				}
-				if comp.Context().prevRenderComponent.(*componentFunc).id != "original" {
-					panic(`comp.Context().prevRenderComponent.(*componentFunc).id != "original"`)
+				if comp.Context().prevComponent.(*componentFunc).id != "original" {
+					panic(`comp.Context().prevComponent.(*componentFunc).id != "original"`)
 				}
 				if prev.(*componentFunc).id != "original" {
 					panic(`prev.(*componentFunc).id != "original"`)
@@ -1375,9 +1357,6 @@ func TestRerender_change(t *testing.T) {
 			}
 			if comp.Context().prevComponent.(*componentFunc).id != "modified" {
 				t.Fatal(`comp.Context().prevComponent.(*componentFunc).id != "modified"`)
-			}
-			if comp.Context().prevRenderComponent.(*componentFunc).id != "modified" {
-				t.Fatal(`comp.Context().prevRenderComponent.(*componentFunc).id != "modified"`)
 			}
 			if bodyAppendChild != newNode {
 				t.Fatal("bodyAppendChild != newNode")
@@ -1495,7 +1474,7 @@ func TestRenderBody_RenderSkipper_Skip(t *testing.T) {
 		},
 	}
 	fakePrevRender := *comp
-	comp.Context().prevRenderComponent = &fakePrevRender
+	comp.Context().prevComponent = &fakePrevRender
 	got := recoverStr(func() {
 		RenderBody(comp)
 	})

--- a/dom_test.go
+++ b/dom_test.go
@@ -928,8 +928,7 @@ func TestHTML_reconcile_nil(t *testing.T) {
 			},
 		}
 		var (
-			compRenderCalls, compRestoreCalls int
-			compRestore                       Component
+			compRenderCalls int
 		)
 		compRender := Tag("div")
 		comp := &componentFunc{
@@ -937,10 +936,6 @@ func TestHTML_reconcile_nil(t *testing.T) {
 			render: func() *HTML {
 				compRenderCalls++
 				return compRender
-			},
-			restore: func(prev Component) {
-				compRestoreCalls++
-				compRestore = prev
 			},
 		}
 		h := Tag("div", Tag("div", comp))
@@ -950,12 +945,6 @@ func TestHTML_reconcile_nil(t *testing.T) {
 		}
 		if compRenderCalls != 1 {
 			t.Fatal("compRenderCalls != 1")
-		}
-		if compRestoreCalls != 1 {
-			t.Fatal("compRestoreCalls != 1")
-		}
-		if compRestore != nil {
-			t.Fatal("compRestore != nil")
 		}
 		if comp.Context().prevComponent != comp {
 			t.Fatal("comp.Context().prevComponent != comp")
@@ -1017,18 +1006,13 @@ func TestHTML_reconcile_nil(t *testing.T) {
 			},
 		}
 		var (
-			compRenderCalls, compRestoreCalls int
-			compRestore                       Component
+			compRenderCalls int
 		)
 		comp := &componentFunc{
 			id: "foobar",
 			render: func() *HTML {
 				compRenderCalls++
 				return nil
-			},
-			restore: func(prev Component) {
-				compRestoreCalls++
-				compRestore = prev
 			},
 		}
 		h := Tag("div", Tag("div", comp))
@@ -1038,12 +1022,6 @@ func TestHTML_reconcile_nil(t *testing.T) {
 		}
 		if compRenderCalls != 1 {
 			t.Fatal("compRenderCalls != 1")
-		}
-		if compRestoreCalls != 1 {
-			t.Fatal("compRestoreCalls != 1")
-		}
-		if compRestore != nil {
-			t.Fatal("compRestore != nil")
 		}
 		if comp.Context().prevComponent != comp {
 			t.Fatal("comp.Context().prevComponent != comp")
@@ -1127,9 +1105,6 @@ func TestRerender_no_prevRender(t *testing.T) {
 			render: func() *HTML {
 				panic("expected no Render call")
 			},
-			restore: func(prev Component) {
-				panic("expected no Restore call")
-			},
 			skipRender: func(prev Component) bool {
 				panic("expected no SkipRender call")
 			},
@@ -1180,18 +1155,12 @@ func TestRerender_identical(t *testing.T) {
 	}
 
 	render := Tag("body")
-	var renderCalled, restoreCalled, skipRenderCalled int
+	var renderCalled, skipRenderCalled int
 	comp := &componentFunc{
 		id: "original",
 		render: func() *HTML {
 			renderCalled++
 			return render
-		},
-		restore: func(prev Component) {
-			if prev != nil {
-				panic("prev != nil")
-			}
-			restoreCalled++
 		},
 	}
 	RenderBody(comp)
@@ -1200,9 +1169,6 @@ func TestRerender_identical(t *testing.T) {
 	}
 	if renderCalled != 1 {
 		t.Fatal("renderCalled != 1")
-	}
-	if restoreCalled != 1 {
-		t.Fatal("restoreCalled != 1")
 	}
 	if comp.Context().prevRender != render {
 		t.Fatal("comp.Context().prevRender != render")
@@ -1222,7 +1188,6 @@ func TestRerender_identical(t *testing.T) {
 		renderCalled++
 		return newRender
 	}
-	comp.restore = nil
 	comp.skipRender = func(prev Component) bool {
 		if comp.id != "modified" {
 			panic(`comp.id != "modified"`)
@@ -1242,9 +1207,6 @@ func TestRerender_identical(t *testing.T) {
 	Rerender(comp)
 	if renderCalled != 2 {
 		t.Fatal("renderCalled != 2")
-	}
-	if restoreCalled != 1 {
-		t.Fatal("restoreCalled != 1")
 	}
 	if skipRenderCalled != 1 {
 		t.Fatal("skipRenderCalled != 1")
@@ -1330,18 +1292,12 @@ func TestRerender_change(t *testing.T) {
 			}
 
 			render := Tag("body")
-			var renderCalled, restoreCalled, skipRenderCalled int
+			var renderCalled, skipRenderCalled int
 			comp := &componentFunc{
 				id: "original",
 				render: func() *HTML {
 					renderCalled++
 					return render
-				},
-				restore: func(prev Component) {
-					if prev != nil {
-						panic("prev != nil")
-					}
-					restoreCalled++
 				},
 			}
 			RenderBody(comp)
@@ -1350,9 +1306,6 @@ func TestRerender_change(t *testing.T) {
 			}
 			if renderCalled != 1 {
 				t.Fatal("renderCalled != 1")
-			}
-			if restoreCalled != 1 {
-				t.Fatal("restoreCalled != 1")
 			}
 			if comp.Context().prevRender != render {
 				t.Fatal("comp.Context().prevRender != render")
@@ -1394,7 +1347,6 @@ func TestRerender_change(t *testing.T) {
 				renderCalled++
 				return tst.newRender
 			}
-			comp.restore = nil
 			comp.skipRender = func(prev Component) bool {
 				if comp.id != "modified" {
 					panic(`comp.id != "modified"`)
@@ -1414,9 +1366,6 @@ func TestRerender_change(t *testing.T) {
 			Rerender(comp)
 			if renderCalled != 2 {
 				t.Fatal("renderCalled != 2")
-			}
-			if restoreCalled != 1 {
-				t.Fatal("restoreCalled != 1")
 			}
 			if skipRenderCalled != 1 {
 				t.Fatal("skipRenderCalled != 1")
@@ -1493,7 +1442,6 @@ func TestRenderBody_ExpectsBody(t *testing.T) {
 					render: func() *HTML {
 						return c.render
 					},
-					restore:    func(prev Component) {},
 					skipRender: func(prev Component) bool { return false },
 				})
 			}()
@@ -1504,9 +1452,9 @@ func TestRenderBody_ExpectsBody(t *testing.T) {
 	}
 }
 
-// TestRenderBody_Restore_Skip tests that RenderBody panics when the
-// component's Restore method returns skip == true.
-func TestRenderBody_Restore_Skip(t *testing.T) {
+// TestRenderBody_RenderSkipper_Skip tests that RenderBody panics when the
+// component's SkipRender method returns skip == true.
+func TestRenderBody_RenderSkipper_Skip(t *testing.T) {
 	body := &mockObject{}
 	document := &mockObject{
 		call: func(name string, args ...interface{}) jsObject {
@@ -1544,8 +1492,6 @@ func TestRenderBody_Restore_Skip(t *testing.T) {
 		},
 		skipRender: func(prev Component) bool {
 			return true
-		},
-		restore: func(prev Component) {
 		},
 	}
 	fakePrevRender := *comp
@@ -1554,68 +1500,6 @@ func TestRenderBody_Restore_Skip(t *testing.T) {
 		RenderBody(comp)
 	})
 	want := "vecty: RenderBody Component.SkipRender returned true"
-	if got != want {
-		t.Fatalf("got panic %q want %q", got, want)
-	}
-}
-
-// TestRenderBody_Restore_Before_SkipRender tests that RenderBody calls the
-// component's Restore method before calling its SkipRender.
-func TestRenderBody_Restore_Before_SkipRender(t *testing.T) {
-	body := &mockObject{}
-	document := &mockObject{
-		call: func(name string, args ...interface{}) jsObject {
-			if name != "createElement" {
-				panic(fmt.Sprintf("expected call to createElement, not %q", name))
-			}
-			if len(args) != 1 {
-				panic("len(args) != 1")
-			}
-			if args[0].(string) != "body" {
-				panic(`args[0].(string) != "body"`)
-			}
-			return body
-		},
-		get: map[string]jsObject{
-			"readyState": &mockObject{stringValue: "complete"},
-		},
-		set: func(key string, value interface{}) {
-			if key != "body" {
-				panic(fmt.Sprintf(`expected document.set "body", not %q`, key))
-			}
-			if value != body {
-				panic(fmt.Sprintf(`expected document.set body value, not %T %+v`, value, value))
-			}
-		},
-	}
-	global = &mockObject{
-		get: map[string]jsObject{
-			"document": document,
-		},
-	}
-
-	didRestore := false
-	want := "test: SkipRender called after Restore"
-	comp := &componentFunc{
-		render: func() *HTML {
-			return Tag("body")
-		},
-		skipRender: func(prev Component) bool {
-			if didRestore {
-				// Short-circuit if call order is correct.
-				panic(want)
-			}
-			return true
-		},
-		restore: func(prev Component) {
-			didRestore = true
-		},
-	}
-	fakePrevRender := *comp
-	comp.Context().prevRenderComponent = &fakePrevRender
-	got := recoverStr(func() {
-		RenderBody(comp)
-	})
 	if got != want {
 		t.Fatalf("got panic %q want %q", got, want)
 	}
@@ -1658,21 +1542,11 @@ func TestRenderBody_Standard_loaded(t *testing.T) {
 			"document": document,
 		},
 	}
-	var restoreCalled bool
 	RenderBody(&componentFunc{
 		render: func() *HTML {
 			return Tag("body")
 		},
-		restore: func(prev Component) {
-			if prev != nil {
-				t.Fatal("prev != nil")
-			}
-			restoreCalled = true
-		},
 	})
-	if !restoreCalled {
-		t.Fatal("expected Restore to be called")
-	}
 	if !bodySet {
 		t.Fatalf("expected document.body to be set")
 	}
@@ -1727,21 +1601,11 @@ func TestRenderBody_Standard_loading(t *testing.T) {
 			"document": document,
 		},
 	}
-	var restoreCalled bool
 	RenderBody(&componentFunc{
 		render: func() *HTML {
 			return Tag("body")
 		},
-		restore: func(prev Component) {
-			if prev != nil {
-				t.Fatal("prev != nil")
-			}
-			restoreCalled = true
-		},
 	})
-	if !restoreCalled {
-		t.Fatal("expected Restore to be called")
-	}
 	if domLoadedEventListener == nil {
 		t.Fatalf("domLoadedEventListener == nil")
 	}
@@ -1866,12 +1730,10 @@ type componentFunc struct {
 	Core
 	id         string
 	render     func() *HTML
-	restore    func(prev Component)
 	skipRender func(prev Component) bool
 }
 
 func (c *componentFunc) Render() *HTML                  { return c.render() }
-func (c *componentFunc) Restore(prev Component)         { c.restore(prev) }
 func (c *componentFunc) SkipRender(prev Component) bool { return c.skipRender(prev) }
 
 type mockObject struct {

--- a/example/markdown/markdown.go
+++ b/example/markdown/markdown.go
@@ -54,7 +54,7 @@ func (p *PageView) Render() *vecty.HTML {
 // HTML into a div.
 type Markdown struct {
 	vecty.Core
-	Input string
+	Input string `vecty:"prop"`
 }
 
 // Render implements the vecty.Component interface.

--- a/example/todomvc/components/filterbutton.go
+++ b/example/todomvc/components/filterbutton.go
@@ -16,8 +16,8 @@ import (
 type FilterButton struct {
 	vecty.Core
 
-	Label  string
-	Filter model.FilterState
+	Label  string            `vecty:"prop"`
+	Filter model.FilterState `vecty:"prop"`
 }
 
 func (b *FilterButton) onClick(event *vecty.Event) {

--- a/example/todomvc/components/itemview.go
+++ b/example/todomvc/components/itemview.go
@@ -16,8 +16,8 @@ import (
 type ItemView struct {
 	vecty.Core
 
-	Index     int
-	Item      *model.Item
+	Index     int         `vecty:"prop"`
+	Item      *model.Item `vecty:"prop"`
 	editing   bool
 	editTitle string
 	input     *vecty.HTML

--- a/example/todomvc/components/pageview.go
+++ b/example/todomvc/components/pageview.go
@@ -18,7 +18,7 @@ import (
 type PageView struct {
 	vecty.Core
 
-	Items        []*model.Item
+	Items        []*model.Item `vecty:"prop"`
 	newItemTitle string
 }
 

--- a/markup.go
+++ b/markup.go
@@ -170,7 +170,19 @@ func If(cond bool, markup ...MarkupOrComponentOrHTML) MarkupOrComponentOrHTML {
 	if cond {
 		return List(markup)
 	}
-	return nil
+	var result []MarkupOrComponentOrHTML
+	for _, m := range markup {
+		if m == nil {
+			continue
+		}
+		switch m.(type) {
+		case *HTML, Component:
+			result = append(result, Tag("noscript"))
+		default:
+			return nil
+		}
+	}
+	return List(result)
 }
 
 // UnsafeHTML is Markup which unsafely sets the inner HTML of an HTML element.


### PR DESCRIPTION
Second pass at implementing persistent component references.  Main differences to #130 are checks for compatible child types, simplified render args, and added child stability when using `vecty.If()`.

The requirement for the latter does illustrate possibly surprising behaviour for people rendering lists with changing children, that I was expecting to encounter for this implementation because persistence relies on component position amongst siblings to be stable. However, adding the keyed child implementation from #112 and friends in addition to these changes should make it easy to avoid this pitfall for more complex use-cases.  I do wonder thought whether we shouldn't consider trying to use some sort of internal `Noop` HTML type that gets skipped for rendering output, but is retained as a HTML child on the struct, so that we don't litter the DOM with `<noscript>` elems.

I still need to look at how to write tests for this stuff.

Fixes #115