### PR TITLE
handle nil *HTML in render

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -543,6 +543,9 @@ func copyProps(src, dst Component) {
 func render(next, prev ComponentOrHTML) (h *HTML, skip bool) {
 	switch v := next.(type) {
 	case *HTML:
+		if v == nil {
+			return nil, false
+		}
 		// Cases 1, 2 and 3 above. Reconcile against the prevRender.
 		v.reconcile(extractHTML(prev))
 		return v, false

--- a/dom.go
+++ b/dom.go
@@ -543,9 +543,6 @@ func copyProps(src, dst Component) {
 func render(next, prev ComponentOrHTML) (h *HTML, skip bool) {
 	switch v := next.(type) {
 	case *HTML:
-		if v == nil {
-			return nil, false
-		}
 		// Cases 1, 2 and 3 above. Reconcile against the prevRender.
 		v.reconcile(extractHTML(prev))
 		return v, false

--- a/markup.go
+++ b/markup.go
@@ -61,7 +61,13 @@ func apply(m MarkupOrChild, h *HTML) {
 	switch m := m.(type) {
 	case MarkupList:
 		m.Apply(h)
-	case Component, *HTML, List, nil:
+	case *HTML:
+		if m == nil {
+			h.children = append(h.children, nil)
+			return
+		}
+		h.children = append(h.children, m)
+	case Component, List, nil:
 		h.children = append(h.children, m)
 	default:
 		panic(fmt.Sprintf("vecty: invalid type %T does not match MarkupOrChild interface", m))


### PR DESCRIPTION
This change fixes a regression introduced by PR #134.

The basic issue is that when `nil` is encountered, it is treated correctly as a nil render,
but when `(*HTML)(nil)` is encountered, it is not. I discovered this while porting
Go-Package-Store (which uses Vecty) over to the new API.

The following code effectively demonstrates the issue:

```Go
package main

import (
	"github.com/gopherjs/vecty"
	"github.com/gopherjs/vecty/elem"
)

func main() {
	vecty.RenderBody(&PageView{})
}

type PageView struct {
	vecty.Core
}

func (p *PageView) Render() *vecty.HTML {
	return elem.Body(
		// this works:
		//nil,

		// this does not:
		p.returnsNil(),
	)
}

func (p *PageView) returnsNil() *vecty.HTML {
	return nil
}
```