### PR TITLE
Remove imports of fmt and strings packages, to reduce binary size

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -1,7 +1,6 @@
 package vecty
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/gopherjs/gopherjs/js"
@@ -494,7 +493,7 @@ func extractHTML(e ComponentOrHTML) *HTML {
 	case Component:
 		return v.Context().prevRender
 	default:
-		panic(fmt.Sprintf("vecty: encountered invalid ComponentOrHTML %T", e))
+		panic("vecty: encountered invalid ComponentOrHTML " + reflect.TypeOf(e).String())
 	}
 }
 
@@ -523,7 +522,7 @@ func doCopy(c Component) Component {
 	// copy.
 	v := reflect.ValueOf(c)
 	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
-		panic(fmt.Sprintf("vecty: Component must be pointer to struct, found %T", c))
+		panic("vecty: Component must be pointer to struct, found " + reflect.TypeOf(c).String())
 	}
 	cpy := reflect.New(v.Elem().Type())
 	cpy.Elem().Set(v.Elem())
@@ -576,7 +575,7 @@ func render(next, prev ComponentOrHTML) (h *HTML, skip bool, pendingMounts []Mou
 	case nil:
 		return nil, false, nil
 	default:
-		panic(fmt.Sprintf("vecty: encountered invalid ComponentOrHTML %T", next))
+		panic("vecty: encountered invalid ComponentOrHTML " + reflect.TypeOf(next).String())
 	}
 }
 
@@ -692,7 +691,7 @@ func RenderBody(body Component) {
 		panic("vecty: RenderBody Component.SkipRender returned true")
 	}
 	if nextRender.tag != "body" {
-		panic(fmt.Sprintf("vecty: RenderBody expected Component.Render to return a body tag, found %q", nextRender.tag))
+		panic("vecty: RenderBody expected Component.Render to return a body tag, found \"" + nextRender.tag + "\"")
 	}
 	doc := global.Get("document")
 	if doc.Get("readyState").String() == "loading" {

--- a/example/todomvc/components/pageview.go
+++ b/example/todomvc/components/pageview.go
@@ -1,7 +1,7 @@
 package components
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/gopherjs/vecty"
 	"github.com/gopherjs/vecty/elem"
@@ -117,7 +117,7 @@ func (p *PageView) renderFooter() *vecty.HTML {
 			),
 
 			elem.Strong(
-				vecty.Text(fmt.Sprintf("%d", count)),
+				vecty.Text(strconv.Itoa(count)),
 			),
 			vecty.Text(itemsLeftText),
 		),
@@ -139,7 +139,7 @@ func (p *PageView) renderFooter() *vecty.HTML {
 					prop.Class("clear-completed"),
 					event.Click(p.onClearCompleted),
 				),
-				vecty.Text(fmt.Sprintf("Clear completed (%d)", store.CompletedItemCount())),
+				vecty.Text("Clear completed ("+strconv.Itoa(store.CompletedItemCount())+")"),
 			),
 		),
 	)

--- a/example/todomvc/example.go
+++ b/example/todomvc/example.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/gopherjs/gopherjs/js"
 	"github.com/gopherjs/vecty"
@@ -31,7 +30,7 @@ func attachLocalStorage() {
 	store.Listeners.Add(nil, func() {
 		data, err := json.Marshal(store.Items)
 		if err != nil {
-			fmt.Printf("failed to store items: %s\n", err)
+			println("failed to store items: " + err.Error())
 		}
 		js.Global.Get("localStorage").Set("items", string(data))
 	})
@@ -39,7 +38,7 @@ func attachLocalStorage() {
 	if data := js.Global.Get("localStorage").Get("items"); data != js.Undefined {
 		var items []*model.Item
 		if err := json.Unmarshal([]byte(data.String()), &items); err != nil {
-			fmt.Printf("failed to load items: %s\n", err)
+			println("failed to load items: " + err.Error())
 		}
 		dispatcher.Dispatch(&actions.ReplaceItems{
 			Items: items,

--- a/example/todomvc/store/storeutil/storeutil.go
+++ b/example/todomvc/store/storeutil/storeutil.go
@@ -1,8 +1,6 @@
 // Package storeutil contains a ListenerRegistry type.
 package storeutil
 
-import "fmt"
-
 // ListenerRegistry is a listener registry.
 // The zero value is unfit for use; use NewListenerRegistry to create an instance.
 type ListenerRegistry struct {
@@ -24,7 +22,7 @@ func (r *ListenerRegistry) Add(key interface{}, listener func()) {
 		key = new(int)
 	}
 	if _, ok := r.listeners[key]; ok {
-		panic(fmt.Sprintf("listener with key already exists: %v", key))
+		panic("duplicate listener key")
 	}
 	r.listeners[key] = listener
 }

--- a/markup.go
+++ b/markup.go
@@ -1,8 +1,7 @@
 package vecty
 
 import (
-	"fmt"
-	"strings"
+	"reflect"
 
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -70,7 +69,7 @@ func apply(m MarkupOrChild, h *HTML) {
 	case Component, List, nil:
 		h.children = append(h.children, m)
 	default:
-		panic(fmt.Sprintf("vecty: invalid type %T does not match MarkupOrChild interface", m))
+		panic("vecty: invalid type " + reflect.TypeOf(m).String() + " does not match MarkupOrChild interface")
 	}
 }
 
@@ -151,7 +150,7 @@ func (m ClassMap) Apply(h *HTML) {
 			classes = append(classes, name)
 		}
 	}
-	Property("className", strings.Join(classes, " ")).Apply(h)
+	Property("className", join(classes, " ")).Apply(h)
 }
 
 // MarkupList represents a list of Applyer which is individually
@@ -225,4 +224,34 @@ func Namespace(uri string) Applyer {
 	return markupFunc(func(h *HTML) {
 		h.namespace = uri
 	})
+}
+
+// join is extracted from the stdlib `strings` package
+func join(a []string, sep string) string {
+	switch len(a) {
+	case 0:
+		return ""
+	case 1:
+		return a[0]
+	case 2:
+		// Special case for common small values.
+		// Remove if golang.org/issue/6714 is fixed
+		return a[0] + sep + a[1]
+	case 3:
+		// Special case for common small values.
+		// Remove if golang.org/issue/6714 is fixed
+		return a[0] + sep + a[1] + sep + a[2]
+	}
+	n := len(sep) * (len(a) - 1)
+	for i := 0; i < len(a); i++ {
+		n += len(a[i])
+	}
+
+	b := make([]byte, n)
+	bp := copy(b, a[0])
+	for _, s := range a[1:] {
+		bp += copy(b[bp:], sep)
+		bp += copy(b[bp:], s)
+	}
+	return string(b)
 }


### PR DESCRIPTION
Helps #144 

Looks like `strconv` is imported by something fairly standard.  I didn't try too hard to track it down, I just removed `fmt` and `strings`.