### PR TITLE
hint at map allocation size when clearing index map of batchRenderer

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -780,7 +780,7 @@ func (b *batchRenderer) render(startTime float64) {
 	// Drain the current batch.
 	pending := b.batch
 	b.batch = nil
-	b.idx = make(map[Component]int)
+	b.idx = make(map[Component]int, len(b.idx))
 
 	// Process batch.
 	for i, c := range pending {


### PR DESCRIPTION
In https://github.com/gopherjs/vecty/pull/152 I hinted that I had one
last suggestion, and this is it.

When we clear `b.idx`, we allocate a new map in its place. This map is
likely to have the same size as the old `b.idx`, so using this as an
allocation size hint in the call to `make` is a good idea.

cc @pdf