### PR TITLE
markup: Multiple Class or ClassMap usage now appends additional classes

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,10 @@ Although v1.0.0 [is not yet out](https://github.com/gopherjs/vecty/milestone/1),
 Pre-v1.0.0 Breaking Changes
 ---------------------------
 
+## Oct 14, 2017 ([PR #155](https://github.com/gopherjs/vecty/pull/155)): major breaking change
+
+The function `prop.Class(string)` has been removed and replaced with `vecty.Class(...string)`.  Migrating users must use the new function and split their classes into separate strings, rather than a single space-separated string.
+
 ## Oct 1, 2017 ([PR #147](https://github.com/gopherjs/vecty/pull/147)): minor breaking change
 
 `MarkupOrChild` and `ComponentOrHTML` can both now contain `KeyedList` (a new type that has been added)

--- a/dom.go
+++ b/dom.go
@@ -121,6 +121,7 @@ type HTML struct {
 	node jsObject
 
 	namespace, tag, text, innerHTML string
+	classes                         map[string]struct{}
 	styles, dataset                 map[string]string
 	properties, attributes          map[string]interface{}
 	eventListeners                  []*EventListener
@@ -243,6 +244,14 @@ func (h *HTML) reconcileProperties(prev *HTML) {
 		}
 	}
 
+	// Classes
+	classList := h.node.Get("classList")
+	for name := range h.classes {
+		if _, ok := prev.classes[name]; !ok {
+			classList.Call("add", name)
+		}
+	}
+
 	// Dataset
 	dataset := h.node.Get("dataset")
 	for name, value := range h.dataset {
@@ -285,6 +294,14 @@ func (h *HTML) removeProperties(prev *HTML) {
 	for name := range prev.attributes {
 		if _, ok := h.attributes[name]; !ok {
 			h.node.Call("removeAttribute", name)
+		}
+	}
+
+	// Classes
+	classList := h.node.Get("classList")
+	for name := range prev.classes {
+		if _, ok := h.classes[name]; !ok {
+			classList.Call("remove", name)
 		}
 	}
 

--- a/example/todomvc/components/filterbutton.go
+++ b/example/todomvc/components/filterbutton.go
@@ -31,7 +31,7 @@ func (b *FilterButton) Render() *vecty.HTML {
 	return elem.ListItem(
 		elem.Anchor(
 			vecty.Markup(
-				vecty.MarkupIf(store.Filter == b.Filter, prop.Class("selected")),
+				vecty.MarkupIf(store.Filter == b.Filter, vecty.Class("selected")),
 				prop.Href("#"),
 				event.Click(b.onClick).PreventDefault(),
 			),

--- a/example/todomvc/components/itemview.go
+++ b/example/todomvc/components/itemview.go
@@ -74,7 +74,7 @@ func (p *ItemView) onStopEdit(event *vecty.Event) {
 func (p *ItemView) Render() *vecty.HTML {
 	p.input = elem.Input(
 		vecty.Markup(
-			prop.Class("edit"),
+			vecty.Class("edit"),
 			prop.Value(p.editTitle),
 			event.Input(p.onEditInput),
 		),
@@ -90,12 +90,12 @@ func (p *ItemView) Render() *vecty.HTML {
 
 		elem.Div(
 			vecty.Markup(
-				prop.Class("view"),
+				vecty.Class("view"),
 			),
 
 			elem.Input(
 				vecty.Markup(
-					prop.Class("toggle"),
+					vecty.Class("toggle"),
 					prop.Type(prop.TypeCheckbox),
 					prop.Checked(p.Item.Completed),
 					event.Change(p.onToggleCompleted),
@@ -109,7 +109,7 @@ func (p *ItemView) Render() *vecty.HTML {
 			),
 			elem.Button(
 				vecty.Markup(
-					prop.Class("destroy"),
+					vecty.Class("destroy"),
 					event.Click(p.onDestroy),
 				),
 			),

--- a/example/todomvc/components/pageview.go
+++ b/example/todomvc/components/pageview.go
@@ -57,7 +57,7 @@ func (p *PageView) Render() *vecty.HTML {
 	return elem.Body(
 		elem.Section(
 			vecty.Markup(
-				prop.Class("todoapp"),
+				vecty.Class("todoapp"),
 			),
 
 			p.renderHeader(),
@@ -74,7 +74,7 @@ func (p *PageView) Render() *vecty.HTML {
 func (p *PageView) renderHeader() *vecty.HTML {
 	return elem.Header(
 		vecty.Markup(
-			prop.Class("header"),
+			vecty.Class("header"),
 		),
 
 		elem.Heading1(
@@ -88,7 +88,7 @@ func (p *PageView) renderHeader() *vecty.HTML {
 
 			elem.Input(
 				vecty.Markup(
-					prop.Class("new-todo"),
+					vecty.Class("new-todo"),
 					prop.Placeholder("What needs to be done?"),
 					prop.Autofocus(true),
 					prop.Value(p.newItemTitle),
@@ -108,12 +108,12 @@ func (p *PageView) renderFooter() *vecty.HTML {
 
 	return elem.Footer(
 		vecty.Markup(
-			prop.Class("footer"),
+			vecty.Class("footer"),
 		),
 
 		elem.Span(
 			vecty.Markup(
-				prop.Class("todo-count"),
+				vecty.Class("todo-count"),
 			),
 
 			elem.Strong(
@@ -124,7 +124,7 @@ func (p *PageView) renderFooter() *vecty.HTML {
 
 		elem.UnorderedList(
 			vecty.Markup(
-				prop.Class("filters"),
+				vecty.Class("filters"),
 			),
 			&FilterButton{Label: "All", Filter: model.All},
 			vecty.Text(" "),
@@ -136,7 +136,7 @@ func (p *PageView) renderFooter() *vecty.HTML {
 		vecty.If(store.CompletedItemCount() > 0,
 			elem.Button(
 				vecty.Markup(
-					prop.Class("clear-completed"),
+					vecty.Class("clear-completed"),
 					event.Click(p.onClearCompleted),
 				),
 				vecty.Text("Clear completed ("+strconv.Itoa(store.CompletedItemCount())+")"),
@@ -148,7 +148,7 @@ func (p *PageView) renderFooter() *vecty.HTML {
 func (p *PageView) renderInfo() *vecty.HTML {
 	return elem.Footer(
 		vecty.Markup(
-			prop.Class("info"),
+			vecty.Class("info"),
 		),
 
 		elem.Paragraph(
@@ -186,13 +186,13 @@ func (p *PageView) renderItemList() *vecty.HTML {
 
 	return elem.Section(
 		vecty.Markup(
-			prop.Class("main"),
+			vecty.Class("main"),
 		),
 
 		elem.Input(
 			vecty.Markup(
+				vecty.Class("toggle-all"),
 				prop.ID("toggle-all"),
-				prop.Class("toggle-all"),
 				prop.Type(prop.TypeCheckbox),
 				prop.Checked(store.CompletedItemCount() == len(store.Items)),
 				event.Change(p.onToggleAllCompleted),
@@ -207,7 +207,7 @@ func (p *PageView) renderItemList() *vecty.HTML {
 
 		elem.UnorderedList(
 			vecty.Markup(
-				prop.Class("todo-list"),
+				vecty.Class("todo-list"),
 			),
 			items,
 		),

--- a/prop/prop.go
+++ b/prop/prop.go
@@ -42,10 +42,6 @@ func Checked(checked bool) vecty.Applyer {
 	return vecty.Property("checked", checked)
 }
 
-func Class(class string) vecty.Applyer {
-	return vecty.Property("className", class)
-}
-
 func For(id string) vecty.Applyer {
 	return vecty.Property("htmlFor", id)
 }


### PR DESCRIPTION
This enables component libraries and composition of elements with
classes.

BREAKING: The function `prop.Class(string)` has been removed and
replaced with `vecty.Class(...string)`.  Migrating users must use the
new function and split their classes into separate strings, rather than
a single space-separated string.

Fixes #80