### PR TITLE
Change Component.Render() signature to return ComponentOrHTML

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,31 @@ Although v1.0.0 [is not yet out](https://github.com/gopherjs/vecty/milestone/1),
 Pre-v1.0.0 Breaking Changes
 ---------------------------
 
+## Nov 4, 2017 ([PR #158](https://github.com/gopherjs/vecty/pull/158)): major breaking change
+
+All `Component`s must now have a `Render` method which returns `vecty.ComponentOrHTML` instead of the prior `*vecty.HTML` type.
+
+This change allows for higher order components (components that themselves render components), which is useful for many more advanced uses of Vecty.
+
+### Upgrading
+
+Upgrading most codebases should be trivial with a find-and-replace across all files.
+
+From your editor:
+* Find `) Render() *vecty.HTML` and replace with `) Render() vecty.ComponentOrHTML`.
+
+From the __Linux__ command line:
+```bash
+git grep -l ') Render() \*vecty.HTML' | xargs sed -i 's/) Render() \*vecty.HTML/) Render() vecty.ComponentOrHTML/g'
+```
+
+From the __Mac__ command line:
+```bash
+git grep -l ') Render() \*vecty.HTML' | xargs sed -i '' -e 's/) Render() \*vecty.HTML/) Render() vecty.ComponentOrHTML/g'
+```
+
+Obviously, you'll still need to verify that this only modifies your `Component` implementations. No other changes are needed, and no behavior change is expected for components that return `*vecty.HTML` (as the new `vecty.ComponentOrHTML` interface return type).
+
 ## Oct 14, 2017 ([PR #155](https://github.com/gopherjs/vecty/pull/155)): major breaking change
 
 The function `prop.Class(string)` has been removed and replaced with `vecty.Class(...string)`.  Migrating users must use the new function and split their classes into separate strings, rather than a single space-separated string.

--- a/example/markdown/markdown.go
+++ b/example/markdown/markdown.go
@@ -25,7 +25,7 @@ type PageView struct {
 }
 
 // Render implements the vecty.Component interface.
-func (p *PageView) Render() *vecty.HTML {
+func (p *PageView) Render() vecty.ComponentOrHTML {
 	return elem.Body(
 		// Display a textarea on the right-hand side of the page.
 		elem.Div(
@@ -62,7 +62,7 @@ type Markdown struct {
 }
 
 // Render implements the vecty.Component interface.
-func (m *Markdown) Render() *vecty.HTML {
+func (m *Markdown) Render() vecty.ComponentOrHTML {
 	// Render the markdown input into HTML using Blackfriday.
 	unsafeHTML := blackfriday.MarkdownCommon([]byte(m.Input))
 

--- a/example/todomvc/components/filterbutton.go
+++ b/example/todomvc/components/filterbutton.go
@@ -27,7 +27,7 @@ func (b *FilterButton) onClick(event *vecty.Event) {
 }
 
 // Render implements the vecty.Component interface.
-func (b *FilterButton) Render() *vecty.HTML {
+func (b *FilterButton) Render() vecty.ComponentOrHTML {
 	return elem.ListItem(
 		elem.Anchor(
 			vecty.Markup(

--- a/example/todomvc/components/itemview.go
+++ b/example/todomvc/components/itemview.go
@@ -71,7 +71,7 @@ func (p *ItemView) onStopEdit(event *vecty.Event) {
 }
 
 // Render implements the vecty.Component interface.
-func (p *ItemView) Render() *vecty.HTML {
+func (p *ItemView) Render() vecty.ComponentOrHTML {
 	p.input = elem.Input(
 		vecty.Markup(
 			vecty.Class("edit"),

--- a/example/todomvc/components/pageview.go
+++ b/example/todomvc/components/pageview.go
@@ -53,7 +53,7 @@ func (p *PageView) onToggleAllCompleted(event *vecty.Event) {
 }
 
 // Render implements the vecty.Component interface.
-func (p *PageView) Render() *vecty.HTML {
+func (p *PageView) Render() vecty.ComponentOrHTML {
 	return elem.Body(
 		elem.Section(
 			vecty.Markup(


### PR DESCRIPTION
This allows nesting of Components, allowing the creation of wrapper
components that implement lifcycle events, but do not directly render
HTML.

BREAKING: This change breaks all existing Component implementations due
to change of method signature.

Fixes #148