### PR TITLE
Ensure ComponentOrHTML satisfies MarkupOrChild.

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -105,6 +105,7 @@ type Keyer interface {
 // underlying value must be one of these types.
 type ComponentOrHTML interface {
 	isComponentOrHTML()
+	isMarkupOrChild()
 }
 
 // RenderSkipper is an optional interface that Component's can implement in


### PR DESCRIPTION
This avoids some awkwardness, and API breakage for users returning
ComponentOrHTML from funcs as children in element constructors.

Refs #159, #161, #156