### PR TITLE
produce better error message when vecty.Class fails

### DIFF
--- a/markup.go
+++ b/markup.go
@@ -166,10 +166,7 @@ func Class(class ...string) Applyer {
 func mustValidateClassNames(class []string) {
 	for _, name := range class {
 		if containsSpace(name) {
-			panic(
-				`vecty: invalid class string "` + name + `" with spaces passed to ` + "`vecty.Class` -- " +
-					`you must pass each name as a separate argument`,
-			)
+			panic(`vecty: invalid argument to vecty.Class "` + name + `" (string may not contain spaces)`)
 		}
 	}
 }

--- a/markup.go
+++ b/markup.go
@@ -166,7 +166,10 @@ func Class(class ...string) Applyer {
 func mustValidateClassNames(class []string) {
 	for _, name := range class {
 		if containsSpace(name) {
-			failClassName(name)
+			panic(
+				`vecty: invalid class string "` + name + `" with spaces passed to ` + "`vecty.Class` -- " +
+					`you must pass each name as a separate argument`,
+			)
 		}
 	}
 }
@@ -179,14 +182,6 @@ func containsSpace(s string) bool {
 		}
 	}
 	return false
-}
-
-// failClassName produces a helpful error message to fix the spaces in vecty.Class.
-func failClassName(name string) {
-	panic(
-		`vecty: invalid class string "` + name + `" with spaces passed to ` + "`vecty.Class` -- " +
-			`you must pass each name as a separate argument`,
-	)
 }
 
 // ClassMap is markup that specifies classes to be applied to an element if

--- a/markup.go
+++ b/markup.go
@@ -2,7 +2,6 @@ package vecty
 
 import (
 	"reflect"
-	"strings"
 
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -166,28 +165,27 @@ func Class(class ...string) Applyer {
 // and panics with clear instructions on how to fix this user error.
 func mustValidateClassNames(class []string) {
 	for _, name := range class {
-		if strings.Contains(name, " ") {
+		if containsSpace(name) {
 			failClassName(name)
 		}
 	}
 }
 
-// failClassName produces a helpful error message.
-// to fix the spaces in vecty.Class for example:
-// vecty.Class("hello there") will result in the following panic:
-// Spaces are not allowed in class names. Use `vecty.Class("hello", "there")` instead of `vecty.Class("hello there")`
-func failClassName(name string) {
-	names := []string{}
-	// avoids using fmt.Sprintf for bundle size optimization.
-	for _, cn := range strings.Split(name, " ") {
-		cn = "\"" + cn + "\""
-		names = append(names, cn)
+// containsSpace reports whether s contains a space character.
+func containsSpace(s string) bool {
+	for _, c := range s {
+		if c == ' ' {
+			return true
+		}
 	}
-	correct := strings.Join(names, ", ")
-	incorrect := "\"" + name + "\""
+	return false
+}
+
+// failClassName produces a helpful error message to fix the spaces in vecty.Class.
+func failClassName(name string) {
 	panic(
-		"Spaces are not allowed in class names. Use `vecty.Class(" + correct + ")` " +
-			"instead of `vecty.Class(" + incorrect + ")`",
+		`vecty: invalid class string "` + name + `" with spaces passed to ` + "`vecty.Class` -- " +
+			`you must pass each name as a separate argument`,
 	)
 }
 


### PR DESCRIPTION
While I was updating my repos to fix vecty breaking changes, I forgot to separate some spaced-classes in `vecty.Class` and the error message that I got was super confusing. I can imagine newcomers to be terrified and/or turned off by confusing dom error messages (picture below).

This pr produces a better error message with instructions on how to fix their code.  

**before** 

<img width="1439" alt="screen shot 2017-11-21 at 3 06 47 pm" src="https://user-images.githubusercontent.com/16294261/33096185-212059c4-ced4-11e7-93cf-ba1574f98fe1.png">

**after** 

<img width="1437" alt="screen shot 2017-11-21 at 3 58 27 pm" src="https://user-images.githubusercontent.com/16294261/33096408-e74f0ffa-ced4-11e7-9912-45e38a67c63a.png">

