### PR TITLE
example: remove usage of the Restorer interface

### DIFF
--- a/example/todomvc/components/itemview.go
+++ b/example/todomvc/components/itemview.go
@@ -23,14 +23,6 @@ type ItemView struct {
 	input     *vecty.HTML
 }
 
-// Restore implements the vecty.Restorer interface.
-func (p *ItemView) Restore(prev vecty.Component) {
-	if old, ok := prev.(*ItemView); ok {
-		p.editing = old.editing
-		p.editTitle = old.editTitle
-	}
-}
-
 // Key implements the vecty.Keyer interface.
 func (p *ItemView) Key() interface{} {
 	return p.Index

--- a/example/todomvc/components/pageview.go
+++ b/example/todomvc/components/pageview.go
@@ -22,13 +22,6 @@ type PageView struct {
 	newItemTitle string
 }
 
-// Restore implements the vecty.Restorer interface.
-func (p *PageView) Restore(prev vecty.Component) {
-	if old, ok := prev.(*PageView); ok {
-		p.newItemTitle = old.newItemTitle
-	}
-}
-
 func (p *PageView) onNewItemTitleInput(event *vecty.Event) {
 	p.newItemTitle = event.Target.Get("value").String()
 	vecty.Rerender(p)


### PR DESCRIPTION
Fix #174

This interface has been removed in PR #130, it shouldn't be used
anymore.