### PR TITLE
fix batchRender.add slice index out of boundary bug

### DIFF
--- a/dom.go
+++ b/dom.go
@@ -822,7 +822,7 @@ func (b *batchRenderer) add(c Component) {
 	if i, ok := b.idx[c]; ok {
 		// Shift idx for delete.
 		for j, c := range b.batch[i+1:] {
-			b.idx[c] = j - 1
+			b.idx[c] = i + j
 		}
 		// Delete previously queued render.
 		copy(b.batch[i:], b.batch[i+1:])


### PR DESCRIPTION
https://github.com/gopherjs/vecty/blob/03a16cfdc96974c7afdc9aa784b4a91b0964c359/dom.go#L825

I think here should be "i + j", just skip the i-th item