### PR TITLE
Allow `vecty.HTML` to participate in the lifecycle of the node (for discussion)

### DIFF
--- a/markup.go
+++ b/markup.go
@@ -104,6 +104,18 @@ func Key(key interface{}) Applyer {
 	})
 }
 
+func OnMount(cb func(h *HTML)) Applyer {
+	return markupFunc(func(h *HTML) {
+		h.mounters = append(h.mounters, cb)
+	})
+}
+
+func OnUnmount(cb func(h *HTML)) Applyer {
+	return markupFunc(func(h *HTML) {
+		h.unmounters = append(h.unmounters, cb)
+	})
+}
+
 // Property returns an Applyer which applies the given JavaScript property to an
 // HTML element or text node. Generally, this function is not used directly but
 // rather the prop and style subpackages (which are type safe) should be used instead.


### PR DESCRIPTION
There are very few differences between `*vecty.HTML` and `vecty.Component` right now. One of them is that a component has a `Render` method, while a `*vecty.HTML` is already fully rendered. The other is that `*vecty.HTML` cannot participate in its own lifecycle: it doesn't have a way to react to being mounted or unmounted.

Changing this is actually almost trivial, because we _already_ check if any element of the hierarchy is a `vecty.Mounter` or a `vecty.Unmounter`. We just need to implement `HTML.Mount` and `HTML.Unmount`, and wire them into an applier.