### PR TITLE
switch to golangci-lint for linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+# This file contains our configuration for golangci-lint; see https://github.com/golangci/golangci-lint
+# for more information.
+
+linters:
+  enable:
+    - golint
+
+issues:
+  # We do not use golangci-lint's default list of exclusions because some of
+  # them are not good for us (we prefer strictness):
+  #
+  # - Not requiring published functions to have comments.
+  # - Not warning about ineffective break statements.
+  # - And more that don't effect Vecty itself.
+  #
+  exclude-use-default: false
+
+  # List of regexps of issue texts to exclude, empty list by default.
+  exclude:
+    # https://github.com/gopherjs/vecty/issues/224
+    - "const TypeUrl should be TypeURL"
+
+    # https://github.com/gopherjs/vecty/issues/226
+    - "comment on exported function Timeout should be of the form"
+
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+
+    # golint: False positive when tests are defined in package 'test'
+    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ install:
   - nvm install 9.11
   - npm install -g source-map-support
   - go get -u github.com/gopherjs/gopherjs
-  - go get -u github.com/golang/lint/golint
-  - go get -u honnef.co/go/tools/cmd/megacheck
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.12.5
   - go get -u github.com/haya14busa/goverage
   - npm install --global node-gyp
 before_script:
@@ -24,13 +23,14 @@ script:
   # Fetch dependencies.
   - go get -t -v ./...
 
-  # Consult Go fmt, vet, lint, megacheck tools.
+  # Consult Go fmt to ensure consistent code style.
   - diff -u <(echo -n) <(gofmt -d -s .)
-  - go tool vet .
-  - golint -set_exit_status . ./example/...
-  - golint ./elem/... ./event/... ./prop/... # TODO(slimsag): address these linter errors
-  - megacheck ./...
-  - megacheck -tags=js ./...
+
+  # Consult golangci-lint (multiple Go linting tools).
+  - golangci-lint run . ./elem/... ./event/... ./example/...
+  - golangci-lint run --exclude 'exported .* should have comment .*or be unexported' ./prop/... ./style/... # https://github.com/gopherjs/vecty/issues/227
+  - GOOS=js GOARCH=wasm golangci-lint run --build-tags 'js wasm' . ./elem/... ./event/... ./example/...
+  - GOOS=js GOARCH=wasm golangci-lint run --build-tags 'js wasm' --exclude 'exported .* should have comment .*or be unexported' ./prop/... ./style/... # https://github.com/gopherjs/vecty/issues/227
 
   # Test with Go compiler and GopherJS compiler.
   - go test -v -race ./...


### PR DESCRIPTION
Motivation: With golangci-lint, we no longer have to curate the list of linters that we use and invoke them ourselves. We used to rely on megacheck for this, but it is deprecated in favor of staticcheck which golangci-lint uses by default in addition to also using other good linters.

See https://github.com/golangci/golangci-lint for more information.