### PR TITLE
README: correct bundle sizes (`ls -s` output is bytes not kilobytes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Vecty uses extremely minimal dependencies and prides itself on producing very sm
 
 | Example      | Compiler                | Bundle size | Compressed (gzip) |
 |--------------|-------------------------|-------------|-------------------|
-| `hellovecty` | Go + WebAssembly        | 2.3 KB      | 0.5 KB            |
-| `markdown`   | Go + WebAssembly        | 4.2 KB      | 0.9 KB            |
-| `todomvc`    | Go + WebAssembly        | 3.4 KB      | 0.7 KB            |
-| `hellovecty` | GopherJS                | 0.5 KB      | 0.1 KB            |
-| `markdown`   | GopherJS                | 2.6 KB      | 0.4 KB            |
-| `todomvc`    | GopherJS                | 1.7 KB      | 0.3 KB            |
+| `hellovecty` | Go + WebAssembly        | 2.3 MB      | 0.5 MB            |
+| `markdown`   | Go + WebAssembly        | 4.2 MB      | 0.9 MB            |
+| `todomvc`    | Go + WebAssembly        | 3.4 MB      | 0.7 MB            |
+| `hellovecty` | GopherJS                | 0.5 MB      | 0.1 MB            |
+| `markdown`   | GopherJS                | 2.6 MB      | 0.4 MB            |
+| `todomvc`    | GopherJS                | 1.7 MB      | 0.3 MB            |
 
 Community
 =========


### PR DESCRIPTION
In my rushed attempt to merge WebAssembly support and get an announcement out at 2am last night, my sleep-deprived brain incorrectly parsed the output of `ls -s` in bytes and not kilobytes as is correctly stated in `man ls`. 🤦‍♂ 🤦‍♀

I do believe we can get much smaller bundle sizes, particularly [once we have TInyGo support](https://github.com/tinygo-org/tinygo/issues/93) but it definitely wasn't my goal to mislead everyone here & in the announcement posts.

Apologies for the confusion and to everyone I have misled with this mistake!