### PR TITLE
all: update formatting according to gofumpt

### DIFF
--- a/dom_test.go
+++ b/dom_test.go
@@ -824,8 +824,10 @@ func (c *persistentComponentBody) Render() ComponentOrHTML {
 	)
 }
 
-var lastRenderedComponent Component
-var renderCount int
+var (
+	lastRenderedComponent Component
+	renderCount           int
+)
 
 type persistentComponent struct {
 	Core

--- a/example/todomvc/dispatcher/dispatcher.go
+++ b/example/todomvc/dispatcher/dispatcher.go
@@ -3,8 +3,10 @@ package dispatcher
 // ID is a unique identifier representing a registered callback function.
 type ID int
 
-var idCounter ID
-var callbacks = make(map[ID]func(action interface{}))
+var (
+	idCounter ID
+	callbacks = make(map[ID]func(action interface{}))
+)
 
 // Dispatch dispatches the given action to all registered callbacks.
 func Dispatch(action interface{}) {


### PR DESCRIPTION
This block formatting check was added to the latest version of gofumpt and `master` is currently failing because of it. This fixes it by using the correct formatting.