### PR TITLE
add support for and require Go 1.14+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 install:
-  # Manually download and install Go 1.12 because the Travis / gimme version
-  # is broken (see https://travis-ci.community/t/goos-js-goarch-wasm-go-run-fails-panic-newosproc-not-implemented/1651/6)
-  - wget -O go.tar.gz https://dl.google.com/go/go1.12.linux-amd64.tar.gz
+  # Manually download and install Go 1.14 because the Travis / gimme version
+  # has been broken in the past (see https://travis-ci.community/t/goos-js-goarch-wasm-go-run-fails-panic-newosproc-not-implemented/1651/6)
+  - wget -O go.tar.gz https://dl.google.com/go/go1.14.linux-amd64.tar.gz
   - tar -C ~ -xzf go.tar.gz
   - rm go.tar.gz
   - export GOROOT=~/go
@@ -57,7 +57,8 @@ script:
   # Test with Go compiler (under amd64 and wasm architectures) and GopherJS compiler.
   - go test -race ./...
   - GO111MODULE=on GOOS=js GOARCH=wasm go test -exec="$(go env GOROOT)/misc/wasm/go_js_wasm_exec" ./...
-  - gopherjs test ./...
+  # Disabled until https://github.com/gopherjs/gopherjs/issues/962 is fixed.
+  #- gopherjs test ./...
 
   # Generate and upload coverage to codecov.io
   - goverage -covermode=atomic -coverprofile=coverage.out $(go list ./... | grep -v -e vecty/elem -e vecty/event -e vecty/example -e vecty/prop -e vecty/style)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - npm install --global node-gyp
 
   # Linters, etc.
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+  - GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
   - go get -u github.com/haya14busa/goverage
   - go get -u mvdan.cc/gofumpt
   - go get -u mvdan.cc/gofumpt/gofumports

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,14 @@ Although v1.0.0 [is not yet out](https://github.com/gopherjs/vecty/milestone/1),
 Pre-v1.0.0 Breaking Changes
 ---------------------------
 
+## February 28, 2020 ([PR #256](https://github.com/gopherjs/vecty/pull/256)): indirect breaking change
+
+- Go 1.14+ is now required by Vecty. Users of older Go versions and/or GopherJS (until https://github.com/gopherjs/gopherjs/issues/962 is fixed) may wish to continue using commit `6a0a25ee5a96ce029e684c7da6333aa1f34f8f96`.
+
+## Nov 30, 2019 ([PR #249](https://github.com/gopherjs/vecty/pull/249)): minor breaking change
+
+- `vecty.RenderBody(comp)` is now a blocking function call. Users that rely on it being non-blocking can instead now use `if err := vecty.RenderInto("body", comp); err != nil { panic(err) }`
+
 ## June 30, 2019 ([PR #232](https://github.com/gopherjs/vecty/pull/232)): major breaking change
 
 - `(*HTML).Node` now returns a `syscall/js.Value` instead of `*gopherjs/js.Object`. Users will need to update to the new `syscall/js` API in their applications.

--- a/dom_native.go
+++ b/dom_native.go
@@ -45,7 +45,7 @@ func toLower(s string) string {
 
 var (
 	global    jsObject
-	undefined wrappedObject
+	undefined = wrappedObject{j: &jsObjectImpl{}}
 )
 
 func funcOf(fn func(this jsObject, args []jsObject) interface{}) jsFunc {
@@ -64,6 +64,14 @@ func valueOf(v interface{}) jsObject { return valueOfImpl(v) }
 type wrappedObject struct {
 	jsObject
 	j jsObject
+}
+
+type jsObjectImpl struct {
+	jsObject
+}
+
+func (e *jsObjectImpl) Equal(other jsObject) bool {
+	return e == other.(*jsObjectImpl)
 }
 
 var (

--- a/dom_test.go
+++ b/dom_test.go
@@ -79,7 +79,7 @@ func TestHTML_Node(t *testing.T) {
 
 	x := undefined
 	h := &HTML{node: x}
-	if h.Node() != x.j {
+	if !h.Node().Equal(x.j) {
 		t.Fatal("h.Node() != x")
 	}
 }

--- a/dom_wasmjs_gopherjs.go
+++ b/dom_wasmjs_gopherjs.go
@@ -38,8 +38,8 @@ func toLower(s string) string {
 }
 
 var (
-	global    = wrapObject(js.Global())
-	undefined = wrappedObject{js.Undefined()}
+	global = wrapObject(js.Global())
+	undefined = wrapObject(js.Undefined())
 )
 
 func funcOf(fn func(this jsObject, args []jsObject) interface{}) jsFunc {
@@ -73,11 +73,8 @@ func valueOf(v interface{}) jsObject {
 }
 
 func wrapObject(j js.Value) jsObject {
-	if j == js.Null() {
+	if j.IsNull() {
 		return nil
-	}
-	if j == js.Undefined() {
-		return undefined
 	}
 	return wrappedObject{j: j}
 }
@@ -105,7 +102,7 @@ func (w wrappedObject) Get(key string) jsObject {
 }
 
 func (w wrappedObject) Delete(key string) {
-	w.j.Call("delete", key)
+	w.j.Delete(key)
 }
 
 func (w wrappedObject) Call(name string, args ...interface{}) jsObject {
@@ -121,6 +118,17 @@ func (w wrappedObject) String() string {
 
 func (w wrappedObject) Truthy() bool {
 	return w.j.Truthy()
+}
+
+func (w wrappedObject) IsUndefined() bool {
+	return w.j.IsUndefined()
+}
+
+func (w wrappedObject) Equal(other jsObject) bool {
+	if w.j.IsNull() != (other == nil) {
+		return false
+	}
+	return w.j.Equal(unwrap(other).(js.Value))
 }
 
 func (w wrappedObject) Bool() bool {

--- a/dom_wasmjs_gopherjs.go
+++ b/dom_wasmjs_gopherjs.go
@@ -38,7 +38,7 @@ func toLower(s string) string {
 }
 
 var (
-	global = wrapObject(js.Global())
+	global    = wrapObject(js.Global())
 	undefined = wrapObject(js.Undefined())
 )
 

--- a/dom_wasmjs_gopherjs.go
+++ b/dom_wasmjs_gopherjs.go
@@ -39,7 +39,7 @@ func toLower(s string) string {
 
 var (
 	global    = wrapObject(js.Global())
-	undefined = wrapObject(js.Undefined())
+	undefined = wrappedObject{js.Undefined()}
 )
 
 func funcOf(fn func(this jsObject, args []jsObject) interface{}) jsFunc {

--- a/domutil.go
+++ b/domutil.go
@@ -1,7 +1,7 @@
 package vecty
 
 func replaceNode(newNode, oldNode jsObject) {
-	if newNode == oldNode {
+	if newNode.Equal(oldNode) {
 		return
 	}
 	oldNode.Get("parentNode").Call("replaceChild", newNode, oldNode)

--- a/example/todomvc/example.go
+++ b/example/todomvc/example.go
@@ -35,7 +35,7 @@ func attachLocalStorage() {
 		js.Global().Get("localStorage").Set("items", string(data))
 	})
 
-	if data := js.Global().Get("localStorage").Get("items"); data != js.Undefined() {
+	if data := js.Global().Get("localStorage").Get("items"); !data.IsUndefined() {
 		var items []*model.Item
 		if err := json.Unmarshal([]byte(data.String()), &items); err != nil {
 			println("failed to load items: " + err.Error())

--- a/testsuite_test.go
+++ b/testsuite_test.go
@@ -96,7 +96,7 @@ func (v *valueMocker) get(invocation string) interface{} {
 type testSuiteT struct {
 	t                                      *testing.T
 	callbacks                              map[string]interface{}
-	strings, bools, floats, ints, truthies *valueMocker
+	strings, bools, floats, ints, truthies, isUndefined *valueMocker
 
 	got    string
 	isDone bool
@@ -274,6 +274,9 @@ func (r *objectRecorder) IsUndefined() bool { return r.ts.isUndefined.get(r.name
 
 // Equal implements the jsObject interface.
 func (r *objectRecorder) Equal(other jsObject) bool {
+	if (r == nil) != (other == nil) {
+		return false
+	}
 	return r == other.(*objectRecorder)
 }
 

--- a/testsuite_test.go
+++ b/testsuite_test.go
@@ -47,13 +47,13 @@ func TestMain(m *testing.M) {
 
 func testSuite(t *testing.T) *testSuiteT {
 	ts := &testSuiteT{
-		t:         t,
-		callbacks: make(map[string]interface{}),
-		strings:   &valueMocker{},
-		bools:     &valueMocker{},
-		floats:    &valueMocker{},
-		ints:      &valueMocker{},
-		truthies:  &valueMocker{},
+		t:           t,
+		callbacks:   make(map[string]interface{}),
+		strings:     &valueMocker{},
+		bools:       &valueMocker{},
+		floats:      &valueMocker{},
+		ints:        &valueMocker{},
+		truthies:    &valueMocker{},
 		isUndefined: &valueMocker{},
 	}
 	global = &objectRecorder{

--- a/testsuite_test.go
+++ b/testsuite_test.go
@@ -94,8 +94,8 @@ func (v *valueMocker) get(invocation string) interface{} {
 }
 
 type testSuiteT struct {
-	t                                      *testing.T
-	callbacks                              map[string]interface{}
+	t                                                   *testing.T
+	callbacks                                           map[string]interface{}
 	strings, bools, floats, ints, truthies, isUndefined *valueMocker
 
 	got    string

--- a/testsuite_test.go
+++ b/testsuite_test.go
@@ -54,6 +54,7 @@ func testSuite(t *testing.T) *testSuiteT {
 		floats:    &valueMocker{},
 		ints:      &valueMocker{},
 		truthies:  &valueMocker{},
+		isUndefined: &valueMocker{},
 	}
 	global = &objectRecorder{
 		ts:   ts,
@@ -267,6 +268,14 @@ func (r *objectRecorder) String() string { return r.ts.strings.get(r.name).(stri
 
 // Truthy implements the jsObject interface.
 func (r *objectRecorder) Truthy() bool { return r.ts.truthies.get(r.name).(bool) }
+
+// IsUndefined implements the jsObject interface.
+func (r *objectRecorder) IsUndefined() bool { return r.ts.isUndefined.get(r.name).(bool) }
+
+// Equal implements the jsObject interface.
+func (r *objectRecorder) Equal(other jsObject) bool {
+	return r == other.(*objectRecorder)
+}
 
 // Bool implements the jsObject interface.
 func (r *objectRecorder) Bool() bool { return r.ts.bools.get(r.name).(bool) }


### PR DESCRIPTION
This change adds support for, and changes Vecty to now require, Go 1.14+. For details on how this might impact you refer to the doc/CHANGELOG.md in this PR.

Fixes #244 and supersedes #245
Fixes #253
Also fixes #254