### PR TITLE
example/README: update to reflect Go 1.14+ requirement

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -9,7 +9,7 @@ If you are just getting started, we suggest using the Go 1.14+ WebAssembly suppo
 
 ## Go 1.14+ WebAssembly support
 
-Vecty requires Go 1.14+ as it makes use of [synchronous callback support](https://go-review.googlesource.com/c/go/+/142004) which is not present in earlier versions of Go. **Ensure you are running Go 1.14 or higher.**
+**Ensure you are running Go 1.14 or higher.** Vecty requires Go 1.14+ as it makes use of improvements to the `syscall/js` package which are not present in earlier versions of Go.
 
 ### Running examples
 

--- a/example/README.md
+++ b/example/README.md
@@ -2,20 +2,20 @@
 
 Vecty fully supports two major Go <-> Web compilers thanks to its minimal dependencies:
 
-- Go 1.12+ WebAssembly support
+- Go 1.14+ WebAssembly support
 - [GopherJS](https://github.com/gopherjs/gopherjs) (Go to JavaScript transpiler)
 
-If you are just getting started, we suggest using the Go 1.12+ WebAssembly support.
+If you are just getting started, we suggest using the Go 1.14+ WebAssembly support.
 
-## Go 1.12+ WebAssembly support
+## Go 1.14+ WebAssembly support
 
-Vecty requires Go 1.12+ as it makes use of [synchronous callback support](https://go-review.googlesource.com/c/go/+/142004) which is not present in earlier versions of Go. **Ensure you are running Go 1.12 or higher.**
+Vecty requires Go 1.14+ as it makes use of [synchronous callback support](https://go-review.googlesource.com/c/go/+/142004) which is not present in earlier versions of Go. **Ensure you are running Go 1.14 or higher.**
 
 ### Running examples
 
 The easiest way to run the examples as WebAssembly is via [`wasmserve`](https://github.com/hajimehoshi/wasmserve).
 
-Install it (**using Go 1.12+**):
+Install it (**using Go 1.14+**):
 
 ```bash
 go get -u github.com/hajimehoshi/wasmserve


### PR DESCRIPTION
As reported from the vecty channel.